### PR TITLE
always sort node array for nextstrain import

### DIFF
--- a/taxonium_web_client/src/utils/processNextstrain.js
+++ b/taxonium_web_client/src/utils/processNextstrain.js
@@ -137,8 +137,9 @@ async function processJsTree(tree, data, sendStatusMessage) {
     console.log("ladderizing");
 
     sortWithNumTips(tree.root);
-    tree.node = kn_expand_node(tree.root);
   }
+
+  tree.node = kn_expand_node(tree.root);
 
   sendStatusMessage({
     message: "Laying out the tree",


### PR DESCRIPTION
fixes bug when loading from URL. Calls `kn_expand_node` regardless of if ladderize is true or false, which puts the nodes in the expected downstream order