### PR TITLE
Rename treenome reference

### DIFF
--- a/taxonium_web_client/src/Deck.jsx
+++ b/taxonium_web_client/src/Deck.jsx
@@ -3,6 +3,7 @@ import React, { useState, useCallback, useRef } from "react";
 import DeckGL from "@deck.gl/react";
 import { View } from "@deck.gl/core";
 import useLayers from "./hooks/useLayers";
+import useTreenomeLayers from "./hooks/useTreenomeLayers";
 import JBrowsePanel from "./components/JBrowsePanel";
 import { ClipLoader } from "react-spinners";
 import {
@@ -60,7 +61,7 @@ function Deck({
     (info) => view.setMouseXY([info.x, info.y]),
     [view]
   );
-  const [reference, setReference] = useState(null);
+  const [treenomeReferenceInfo, setTreenomeReferenceInfo] = useState(null);
 
   const [mouseDownIsMinimap, setMouseDownIsMinimap] = useState(false);
 
@@ -177,8 +178,8 @@ function Deck({
     isCurrentlyOutsideBounds,
     config,
     treenomeState,
-    reference,
-    setReference,
+    treenomeReferenceInfo,
+    setTreenomeReferenceInfo,
   });
   // console.log("deck refresh");
 
@@ -301,7 +302,7 @@ function Deck({
             colorHook={colorHook}
             colorBy={colorBy}
             config={config}
-            reference={reference}
+            treenomeReferenceInfo={treenomeReferenceInfo}
           />
           <DeckButtons
             zoomIncrement={zoomIncrement}

--- a/taxonium_web_client/src/Deck.jsx
+++ b/taxonium_web_client/src/Deck.jsx
@@ -3,7 +3,6 @@ import React, { useState, useCallback, useRef } from "react";
 import DeckGL from "@deck.gl/react";
 import { View } from "@deck.gl/core";
 import useLayers from "./hooks/useLayers";
-import useTreenomeLayers from "./hooks/useTreenomeLayers";
 import JBrowsePanel from "./components/JBrowsePanel";
 import { ClipLoader } from "react-spinners";
 import {

--- a/taxonium_web_client/src/components/TreenomeMutationHoverTip.jsx
+++ b/taxonium_web_client/src/components/TreenomeMutationHoverTip.jsx
@@ -4,9 +4,9 @@ const TreenomeMutationHoverTip = ({
   colorHook,
   colorBy,
   config,
-  reference,
+  treenomeReferenceInfo,
 }) => {
-  if (!hoverInfo || !reference) {
+  if (!hoverInfo || !treenomeReferenceInfo) {
     return null;
   }
   const hoveredMutation = hoverInfo.object;
@@ -15,7 +15,7 @@ const TreenomeMutationHoverTip = ({
     return null;
   }
   const posKey = hoveredMutation.m.gene + ":" + hoveredMutation.m.residue_pos;
-  if (hoveredMutation.m.new_residue === reference["aa"][posKey]) {
+  if (hoveredMutation.m.new_residue === treenomeReferenceInfo["aa"][posKey]) {
     return null;
   }
 
@@ -35,7 +35,7 @@ const TreenomeMutationHoverTip = ({
         <div className="mutations text-xs">
           <div className="inline-block">
             <span>{hoveredMutation.m.gene}:</span>
-            <span style={{}}>{reference["aa"][posKey]}</span>
+            <span style={{}}>{treenomeReferenceInfo["aa"][posKey]}</span>
             <span>{hoveredMutation.m.residue_pos}</span>
             <span style={{}}>{hoveredMutation.m.new_residue}</span>
           </div>

--- a/taxonium_web_client/src/hooks/useLayers.js
+++ b/taxonium_web_client/src/hooks/useLayers.js
@@ -24,8 +24,8 @@ const useLayers = ({
   isCurrentlyOutsideBounds,
   config,
   treenomeState,
-  reference,
-  setReference,
+  treenomeReferenceInfo,
+  setTreenomeReferenceInfo,
 }) => {
   const lineColor = [150, 150, 150];
   const getNodeColorField = colorBy.getNodeColorField;
@@ -42,8 +42,8 @@ const useLayers = ({
     colorHook,
     setHoverInfo,
     settings,
-    reference,
-    setReference,
+    treenomeReferenceInfo,
+    setTreenomeReferenceInfo,
     selectedDetails,
     isCurrentlyOutsideBounds
   );

--- a/taxonium_web_client/src/hooks/useTreenomeLayerData.js
+++ b/taxonium_web_client/src/hooks/useTreenomeLayerData.js
@@ -175,7 +175,13 @@ const useTreenomeLayerData = (
     didFirstNt,
   ]);
 
-  return [varDataAa, varDataNt, treenomeReferenceInfo, cachedVarDataAa, cachedVarDataNt];
+  return [
+    varDataAa,
+    varDataNt,
+    treenomeReferenceInfo,
+    cachedVarDataAa,
+    cachedVarDataNt,
+  ];
 };
 
 export default useTreenomeLayerData;

--- a/taxonium_web_client/src/hooks/useTreenomeLayerData.js
+++ b/taxonium_web_client/src/hooks/useTreenomeLayerData.js
@@ -11,7 +11,7 @@ const useTreenomeLayerData = (
   const [numNodes, setNumNodes] = useState(0);
   const [cachedVarDataAa, setCachedVarDataAa] = useState([]);
   const [cachedVarDataNt, setCachedVarDataNt] = useState([]);
-  const [reference, setReference] = useState(null);
+  const [treenomeReferenceInfo, setTreenomeReferenceInfo] = useState(null);
   const [didFirstAa, setDidFirstAa] = useState(false);
   const [didFirstNt, setDidFirstNt] = useState(false);
 
@@ -24,8 +24,8 @@ const useTreenomeLayerData = (
 
   worker.onmessage = useCallback(
     (e) => {
-      if (!reference && e.data.reference) {
-        setReference(e.data.reference);
+      if (!treenomeReferenceInfo && e.data.treenomeReferenceInfo) {
+        setTreenomeReferenceInfo(e.data.treenomeReferenceInfo);
       }
 
       if (e.data.type === "variation_data_return_cache_aa") {
@@ -41,8 +41,8 @@ const useTreenomeLayerData = (
       }
     },
     [
-      reference,
-      setReference,
+      treenomeReferenceInfo,
+      setTreenomeReferenceInfo,
       setVarDataAa,
       setVarDataNt,
       setCachedVarDataAa,
@@ -175,7 +175,7 @@ const useTreenomeLayerData = (
     didFirstNt,
   ]);
 
-  return [varDataAa, varDataNt, reference, cachedVarDataAa, cachedVarDataNt];
+  return [varDataAa, varDataNt, treenomeReferenceInfo, cachedVarDataAa, cachedVarDataNt];
 };
 
 export default useTreenomeLayerData;

--- a/taxonium_web_client/src/hooks/useTreenomeLayers.js
+++ b/taxonium_web_client/src/hooks/useTreenomeLayers.js
@@ -9,8 +9,8 @@ const useTreenomeLayers = (
   colorHook,
   setHoverInfo,
   settings,
-  reference,
-  setReference,
+  treenomeReferenceInfo,
+  setTreenomeReferenceInfo,
   selectedDetails
 ) => {
   const myGetPolygonOffset = ({ layerIndex }) => [0, -(layerIndex + 999) * 100];
@@ -86,10 +86,10 @@ const useTreenomeLayers = (
     cachedVarDataNt,
   ] = useTreenomeLayerData(data, treenomeState, settings);
   useEffect(() => {
-    if (!reference) {
-      setReference(computedReference);
+    if (!treenomeReferenceInfo) {
+      setTreenomeReferenceInfo(computedReference);
     }
-  }, [computedReference, reference, setReference]);
+  }, [computedReference, treenomeReferenceInfo, setTreenomeReferenceInfo]);
   const ntToX = useCallback(
     (nt) => {
       return (
@@ -124,12 +124,12 @@ const useTreenomeLayers = (
     getColor: (d) => {
       if (cov2Genes !== null) {
         return d.m.new_residue !==
-          reference["aa"][d.m.gene + ":" + d.m.residue_pos]
+          treenomeReferenceInfo["aa"][d.m.gene + ":" + d.m.residue_pos]
           ? colorHook.toRGB(d.m.new_residue)
           : cov2Genes[d.m.gene][2].map((c) => 245 - 0.2 * (245 - c));
       } else {
         return d.m.new_residue !==
-          reference["aa"][d.m.gene + ":" + d.m.residue_pos]
+          treenomeReferenceInfo["aa"][d.m.gene + ":" + d.m.residue_pos]
           ? colorHook.toRGB(d.m.new_residue)
           : [245, 245, 245];
       }
@@ -184,7 +184,7 @@ const useTreenomeLayers = (
         aaWidth,
       ],
       getWidth: [aaWidth],
-      getColor: [reference, colorHook, cov2Genes],
+      getColor: [treenomeReferenceInfo, colorHook, cov2Genes],
     },
     getPolygonOffset: myGetPolygonOffset,
   };
@@ -266,7 +266,7 @@ const useTreenomeLayers = (
         ntWidth,
       ],
       getWidth: [ntWidth],
-      getColor: [reference, colorHook, cov2Genes],
+      getColor: [treenomeReferenceInfo, colorHook, cov2Genes],
     },
     getPolygonOffset: myGetPolygonOffset,
   };

--- a/taxonium_web_client/src/webworkers/treenomeWorker.js
+++ b/taxonium_web_client/src/webworkers/treenomeWorker.js
@@ -150,7 +150,7 @@ const computeVariationData = async (data, type, ntBounds, jobId) => {
             ? "variation_data_return_cache_aa"
             : "variation_data_return_cache_nt",
         filteredVarData: filteredVarData,
-        reference: ref,
+        treenomeReferenceInfo: ref,
         jobId: jobId,
       });
     } else {
@@ -160,7 +160,7 @@ const computeVariationData = async (data, type, ntBounds, jobId) => {
             ? "variation_data_return_aa"
             : "variation_data_return_nt",
         filteredVarData: filteredVarData,
-        reference: ref,
+        treenomeReferenceInfo: ref,
         jobId: jobId,
       });
     }


### PR DESCRIPTION
Somehow the "reference" name got me confused. It was a combination of two things:
- I wasn't sure it was treenome-specific (I guess it doesn't have to be in future, but for now it is)
- More majorly I actually didn't get that it meant reference *genome* or similar, I thought it was reference as a programming-term in the sense of [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) or something.

Both of those are kind of foolish on my part but this is an attempt to make it smoother for myself, at the expense of more characters.