### PR TITLE
fix nt mutation colors for back-mutations

### DIFF
--- a/taxonium_web_client/src/components/TreenomeMutationHoverTip.jsx
+++ b/taxonium_web_client/src/components/TreenomeMutationHoverTip.jsx
@@ -18,7 +18,6 @@ const TreenomeMutationHoverTip = ({
   const posKey = isAa
     ? hoveredMutation.m.gene + ":" + hoveredMutation.m.residue_pos
     : hoveredMutation.m.residue_pos;
-  //  console.log(isAa, hoveredMutation, posKey);
   if (
     isAa &&
     hoveredMutation.m.new_residue === treenomeReferenceInfo["aa"][posKey]

--- a/taxonium_web_client/src/components/TreenomeMutationHoverTip.jsx
+++ b/taxonium_web_client/src/components/TreenomeMutationHoverTip.jsx
@@ -14,8 +14,21 @@ const TreenomeMutationHoverTip = ({
   if (!hoveredMutation || !hoveredMutation.m) {
     return null;
   }
-  const posKey = hoveredMutation.m.gene + ":" + hoveredMutation.m.residue_pos;
-  if (hoveredMutation.m.new_residue === treenomeReferenceInfo["aa"][posKey]) {
+  const isAa = hoveredMutation.m.type === "aa";
+  const posKey = isAa
+    ? hoveredMutation.m.gene + ":" + hoveredMutation.m.residue_pos
+    : hoveredMutation.m.residue_pos;
+  //  console.log(isAa, hoveredMutation, posKey);
+  if (
+    isAa &&
+    hoveredMutation.m.new_residue === treenomeReferenceInfo["aa"][posKey]
+  ) {
+    return null;
+  }
+  if (
+    !isAa &&
+    hoveredMutation.m.new_residue === treenomeReferenceInfo["nt"][posKey]
+  ) {
     return null;
   }
 
@@ -35,7 +48,9 @@ const TreenomeMutationHoverTip = ({
         <div className="mutations text-xs">
           <div className="inline-block">
             <span>{hoveredMutation.m.gene}:</span>
-            <span style={{}}>{treenomeReferenceInfo["aa"][posKey]}</span>
+            <span style={{}}>
+              {treenomeReferenceInfo[isAa ? "aa" : "nt"][posKey]}
+            </span>
             <span>{hoveredMutation.m.residue_pos}</span>
             <span style={{}}>{hoveredMutation.m.new_residue}</span>
           </div>

--- a/taxonium_web_client/src/hooks/useTreenomeLayers.js
+++ b/taxonium_web_client/src/hooks/useTreenomeLayers.js
@@ -76,6 +76,21 @@ const useTreenomeLayers = (
     }
   }, [settings.isCov2Tree]);
 
+  const ntToCov2Gene = useCallback(
+    (nt) => {
+      if (cov2Genes !== null) {
+        for (const gene of Object.keys(cov2Genes)) {
+          const [start, end, color] = cov2Genes[gene];
+          if (nt >= start && nt <= end) {
+            return gene;
+          }
+        }
+      }
+      return null;
+    },
+    [cov2Genes]
+  );
+
   let layers = [];
 
   const [
@@ -203,18 +218,33 @@ const useTreenomeLayers = (
     onHover: (info) => setHoverInfo(info),
     pickable: true,
     getColor: (d) => {
+      let color = [0, 0, 0];
       switch (d.m.new_residue) {
         case "A":
-          return [0, 0, 0];
+          color = [0, 0, 0];
+          break;
         case "C":
-          return [60, 60, 60];
+          color = [60, 60, 60];
+          break;
         case "G":
-          return [120, 120, 120];
+          color = [120, 120, 120];
+          break;
         case "T":
-          return [180, 180, 180];
+          color = [180, 180, 180];
+          break;
         default:
-          return [0, 0, 0];
+          color = [0, 0, 0];
+          break;
       }
+      if (cov2Genes !== null) {
+        if (d.m.new_residue === treenomeReferenceInfo["nt"][d.m.residue_pos]) {
+          const gene = ntToCov2Gene(d.m.residue_pos);
+          if (gene !== null) {
+            return cov2Genes[gene][2].map((c) => 245 - 0.2 * (245 - c));
+          }
+        }
+      }
+      return color;
     },
     modelMatrix: modelMatrixFixedX,
     getSourcePosition: (d) => {


### PR DESCRIPTION
This implements the correct coloring scheme for nt mutations in the case of revertant mutations, so the color matches the background when the mutation leads to a reference nt.