### PR TITLE
Helper tool for viewing trees

### DIFF
--- a/taxonium_backend/README.md
+++ b/taxonium_backend/README.md
@@ -18,8 +18,6 @@ then start the dev server for the front-end and go to e.g. http://localhost:3000
 
 If you need to regenerate the data run `make_pandas.py`:
 
-
-
 ## Docker
 
 `docker pull theosanderson/taxonium_backend:master`

--- a/taxoniumtools/setup.cfg
+++ b/taxoniumtools/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     google-api-python-client
     protobuf<4
     orjson
+    psutil
 
 
 [options.packages.find]

--- a/taxoniumtools/setup.cfg
+++ b/taxoniumtools/setup.cfg
@@ -36,3 +36,4 @@ where = src
 [options.entry_points]
 console_scripts =
     usher_to_taxonium = taxoniumtools:usher_to_taxonium.main
+    view_taxonium = taxoniumtools:view_taxonium.main

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -66,7 +66,7 @@ else:
 # something like:
 #docker run -p 80:80 -v "/Users/MyUserName/Desktop/myfile.jsonl.gz:/mnt/data/myfile.jsonl.gz" -e "DATA_FILE=/mnt/data/myfile.jsonl.gz" -e "MAX_MEM=8000" -e "CONFIG_JSON=config_public.json" theosanderson/taxonium_backend:master
 
-backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'"{args.jsonl_gz}:/mnt/data/data.jsonl.gz"', '-e', f'"DATA_FILE=/mnt/data/data.jsonl.gz"', '-e', f'"MAX_MEM={memory}"', '-e', f'"CONFIG_JSON=config_public.json"', BACKEND_IMAGE]
+backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'{args.jsonl_gz}:/mnt/data/data.jsonl.gz:ro', '-e', f'"DATA_FILE=/mnt/data/data.jsonl.gz"', '-e', f'"MAX_MEM={memory}"', '-e', f'"CONFIG_JSON=config_public.json"', BACKEND_IMAGE]
 
 print('Starting backend...')
 backend_process = subprocess.Popen(backend_command)

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -92,3 +92,7 @@ if args.no_frontend:
     print(f'The backend should be running at http://localhost:{args.backend_port}.')
 else:
     print(f'You should be able to access your tree at http://localhost:{args.frontend_port}/?backend=http://localhost:{args.backend_port} in a few minutes.')
+
+
+def main():
+    pass

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -69,19 +69,14 @@ else:
 backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'{args.jsonl_gz}:/mnt/data/data.jsonl.gz:ro', '-e', f'"DATA_FILE=/mnt/data/data.jsonl.gz"', '-e', f'"MAX_MEM={memory}"', '-e', f'"CONFIG_JSON=config_public.json"', BACKEND_IMAGE]
 
 print('Starting backend...')
-backend_process = subprocess.Popen(backend_command)
-backend_id = backend_process.stdout.read().decode('utf-8').strip()
-print(f'Backend started with ID {backend_id}.')
-print(f'Backend should appear on port {args.backend_port} in a few minutes.')
+backend_id = subprocess.check_output(backend_command).decode('utf-8').strip()
+
 
 # Start frontend
 if not args.no_frontend:
     frontend_command = ['docker', 'run', '-d', '-p', f'{args.frontend_port}:80', FRONTEND_IMAGE]
     print('Starting frontend...')
-    frontend_process = subprocess.Popen(frontend_command)
-    frontend_id = frontend_process.stdout.read().decode('utf-8').strip()
-    print(f'Frontend started with ID {frontend_id}.')
-    print(f'Frontend should appear on port {args.frontend_port} in a few minutes.')
+    frontend_id = subprocess.check_output(frontend_command).decode('utf-8').strip()
 
 # Clean up
 def cleanup():

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -93,6 +93,7 @@ if args.no_frontend:
 else:
     print(f'You should be able to access your tree at http://localhost:{args.frontend_port}/?backend=http://localhost:{args.backend_port} in a few minutes.')
 
-
+import time 
 def main():
-    pass
+    while True:
+        time.sleep(1)

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -2,6 +2,7 @@ import atexit
 import subprocess
 import argparse
 import psutil
+import os
 
 BACKEND_IMAGE = "theosanderson/taxonium_backend:master"
 FRONTEND_IMAGE = "theosanderson/taxonium_frontend:master"
@@ -16,8 +17,12 @@ parser.add_argument('--backend_port', type=int, default=5000, help='Port to use 
 parser.add_argument('--frontend_port', type=int, default=8000, help='Port to use for the frontend.')
 
 
+
+
 args = parser.parse_args()
-args = parser.parse_args()
+
+# relative path to absolute:
+args.jsonl_gz = os.path.abspath(args.jsonl_gz)
 
 # Check if docker is installed.
 try:

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -67,7 +67,7 @@ else:
 # something like:
 #docker run -p 80:80 -v "/Users/MyUserName/Desktop/myfile.jsonl.gz:/mnt/data/myfile.jsonl.gz" -e "DATA_FILE=/mnt/data/myfile.jsonl.gz" -e "MAX_MEM=8000" -e "CONFIG_JSON=config_public.json" theosanderson/taxonium_backend:master
 
-backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'{args.jsonl_gz}:/mnt/data/data.jsonl.gz:ro', '-e', f'"DATA_FILE=/mnt/data/data.jsonl.gz"', '-e', f'"MAX_MEM={memory}"', '-e', f'"CONFIG_JSON=config_public.json"', BACKEND_IMAGE]
+backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'{args.jsonl_gz}:/mnt/data/data.jsonl.gz:ro', '-e', f'DATA_FILE=/mnt/data/data.jsonl.gz', '-e', f'MAX_MEM={memory}', '-e', f'CONFIG_JSON=config_public.json', BACKEND_IMAGE]
 
 print('Starting backend...')
 print(f"Running command: {' '.join(backend_command)}")

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -54,8 +54,8 @@ if args.memory:
     memory = args.memory
 else:
     total_memory_in_mb = psutil.virtual_memory().total / 1024 / 1024
-    suggested_memory = int(total_memory_in_mb * 0.8)
-    print(f'No memory specified. Using {suggested_memory} MB for the backend. You can modify this with the --memory argument.')
+    memory = int(total_memory_in_mb * 0.8)
+    print(f'No memory specified. Using {memory} MB for the backend. You can modify this with the --memory argument.')
 
 
 

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -70,6 +70,7 @@ else:
 backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'{args.jsonl_gz}:/mnt/data/data.jsonl.gz:ro', '-e', f'"DATA_FILE=/mnt/data/data.jsonl.gz"', '-e', f'"MAX_MEM={memory}"', '-e', f'"CONFIG_JSON=config_public.json"', BACKEND_IMAGE]
 
 print('Starting backend...')
+print(f"Running command: {' '.join(backend_command)}")
 backend_process = subprocess.Popen(backend_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 def wait_for_first_line_of_process(process, timeout=10):
     start_time = time.time()

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -12,13 +12,21 @@ FRONTEND_IMAGE = "theosanderson/taxonium_frontend:master"
 
 parser = argparse.ArgumentParser(description='View a taxonium tree.')
 parser.add_argument('jsonl_gz', type=str, help='Path to a .jsonl.gz file.')
-parser.add_argument('--memory', type=int, default=None, help='Memory in MB for backend.')
-parser.add_argument('--no_frontend', action='store_true', help='Do not start the frontend.')
-parser.add_argument('--backend_port', type=int, default=5000, help='Port to use for the backend.')
-parser.add_argument('--frontend_port', type=int, default=8000, help='Port to use for the frontend.')
-
-
-
+parser.add_argument('--memory',
+                    type=int,
+                    default=None,
+                    help='Memory in MB for backend.')
+parser.add_argument('--no_frontend',
+                    action='store_true',
+                    help='Do not start the frontend.')
+parser.add_argument('--backend_port',
+                    type=int,
+                    default=5000,
+                    help='Port to use for the backend.')
+parser.add_argument('--frontend_port',
+                    type=int,
+                    default=8000,
+                    help='Port to use for the frontend.')
 
 args = parser.parse_args()
 
@@ -29,49 +37,60 @@ args.jsonl_gz = os.path.realpath(args.jsonl_gz)
 try:
     subprocess.check_call(['docker', '--version'])
 except:
-    raise Exception('Docker is not installed. Please install Docker to use this tool.')
+    raise Exception(
+        'Docker is not installed. Please install Docker to use this tool.')
 
 # Check if docker is running.
 try:
     subprocess.check_call(['docker', 'ps'])
 except:
-    raise Exception('Docker is not running. Please start Docker to use this tool.')
+    raise Exception(
+        'Docker is not running. Please start Docker to use this tool.')
 
 # Check if backend image is available.
 try:
     subprocess.check_call(['docker', 'pull', BACKEND_IMAGE])
 except:
-    raise Exception('Could not pull backend image. Please check your internet connection.')
+    raise Exception(
+        'Could not pull backend image. Please check your internet connection.')
 
 if not args.no_frontend:
     # Check if frontend image is available.
     try:
         subprocess.check_call(['docker', 'pull', FRONTEND_IMAGE])
     except:
-        raise Exception('Could not pull frontend image. Please check your internet connection.')
-
+        raise Exception(
+            'Could not pull frontend image. Please check your internet connection.'
+        )
 
 if args.memory:
     memory = args.memory
 else:
     total_memory_in_mb = psutil.virtual_memory().total / 1024 / 1024
     memory = int(total_memory_in_mb * 0.8)
-    print(f'No memory specified. Using {memory} MB for the backend. You can modify this with the --memory argument.')
-
-
-
-
+    print(
+        f'No memory specified. Using {memory} MB for the backend. You can modify this with the --memory argument.'
+    )
 
 # Start backend
 
 # something like:
 #docker run -p 80:80 -v "/Users/MyUserName/Desktop/myfile.jsonl.gz:/mnt/data/myfile.jsonl.gz" -e "DATA_FILE=/mnt/data/myfile.jsonl.gz" -e "MAX_MEM=8000" -e "CONFIG_JSON=config_public.json" theosanderson/taxonium_backend:master
 
-backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'{args.jsonl_gz}:/mnt/data/data.jsonl.gz:ro', '-e', f'DATA_FILE=/mnt/data/data.jsonl.gz', '-e', f'MAX_MEM={memory}', '-e', f'CONFIG_JSON=config_public.json', BACKEND_IMAGE]
+backend_command = [
+    'docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v',
+    f'{args.jsonl_gz}:/mnt/data/data.jsonl.gz:ro', '-e',
+    f'DATA_FILE=/mnt/data/data.jsonl.gz', '-e', f'MAX_MEM={memory}', '-e',
+    f'CONFIG_JSON=config_public.json', BACKEND_IMAGE
+]
 
 print('Starting backend...')
 print(f"Running command: {' '.join(backend_command)}")
-backend_process = subprocess.Popen(backend_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+backend_process = subprocess.Popen(backend_command,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+
+
 def wait_for_first_line_of_process(process, timeout=10):
     start_time = time.time()
     while True:
@@ -80,14 +99,21 @@ def wait_for_first_line_of_process(process, timeout=10):
         line = process.stdout.readline()
         if line:
             return line
-backend_id = wait_for_first_line_of_process(backend_process).decode('utf-8').strip()
+
+
+backend_id = wait_for_first_line_of_process(backend_process).decode(
+    'utf-8').strip()
 print(f'Backend started with id {backend_id}.')
 
 # Start frontend
 if not args.no_frontend:
-    frontend_command = ['docker', 'run', '-d', '-p', f'{args.frontend_port}:80', FRONTEND_IMAGE]
+    frontend_command = [
+        'docker', 'run', '-d', '-p', f'{args.frontend_port}:80', FRONTEND_IMAGE
+    ]
     print('Starting frontend...')
-    frontend_id = subprocess.check_output(frontend_command).decode('utf-8').strip()
+    frontend_id = subprocess.check_output(frontend_command).decode(
+        'utf-8').strip()
+
 
 # Clean up
 def cleanup():
@@ -97,14 +123,21 @@ def cleanup():
     subprocess.check_call(['docker', 'kill', backend_id])
     print('Done.')
 
+
 atexit.register(cleanup)
 
 if args.no_frontend:
-    print(f'The backend should be running at http://localhost:{args.backend_port}.')
+    print(
+        f'The backend should be running at http://localhost:{args.backend_port}.'
+    )
 else:
-    print(f'You should be able to access your tree at http://localhost:{args.frontend_port}/?backend=http://localhost:{args.backend_port} in a few minutes.')
+    print(
+        f'You should be able to access your tree at http://localhost:{args.frontend_port}/?backend=http://localhost:{args.backend_port} in a few minutes.'
+    )
 
-import time 
+import time
+
+
 def main():
     # echo backend output from stderr or stdout to console
     while True:

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -105,5 +105,10 @@ else:
 
 import time 
 def main():
+    # echo backend output to stdout
     while True:
-        time.sleep(1)
+        line = backend_process.stdout.readline()
+        if line:
+            print(line.decode('utf-8').strip())
+        else:
+            time.sleep(1)

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -80,7 +80,7 @@ def wait_for_first_line_of_process(process, timeout=10):
         if line:
             return line
 backend_id = wait_for_first_line_of_process(backend_process).decode('utf-8').strip()
-
+print(f'Backend started with id {backend_id}.')
 
 # Start frontend
 if not args.no_frontend:
@@ -105,10 +105,13 @@ else:
 
 import time 
 def main():
-    # echo backend output to stdout
+    # echo backend output from stderr or stdout to console
     while True:
         line = backend_process.stdout.readline()
         if line:
             print(line.decode('utf-8').strip())
-        else:
-            time.sleep(1)
+        line2 = backend_process.stderr.readline()
+        if line2:
+            print(line2.decode('utf-8').strip())
+        if not line and not line2:
+            time.sleep(0.1)

--- a/taxoniumtools/src/taxoniumtools/view_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium.py
@@ -21,8 +21,8 @@ parser.add_argument('--frontend_port', type=int, default=8000, help='Port to use
 
 args = parser.parse_args()
 
-# relative path to absolute:
-args.jsonl_gz = os.path.abspath(args.jsonl_gz)
+# get the real full path to the jsonl.gz file
+args.jsonl_gz = os.path.realpath(args.jsonl_gz)
 
 # Check if docker is installed.
 try:

--- a/taxoniumtools/src/taxoniumtools/view_taxonium_tree.py
+++ b/taxoniumtools/src/taxoniumtools/view_taxonium_tree.py
@@ -1,0 +1,94 @@
+import atexit
+import subprocess
+import argparse
+import psutil
+
+BACKEND_IMAGE = "theosanderson/taxonium_backend:master"
+FRONTEND_IMAGE = "theosanderson/taxonium_frontend:master"
+
+# Parse arguments, main positional argument is a .jsonl.gz file. Optional argument is memory, with default of None.
+
+parser = argparse.ArgumentParser(description='View a taxonium tree.')
+parser.add_argument('jsonl_gz', type=str, help='Path to a .jsonl.gz file.')
+parser.add_argument('--memory', type=int, default=None, help='Memory in MB for backend.')
+parser.add_argument('--no_frontend', action='store_true', help='Do not start the frontend.')
+parser.add_argument('--backend_port', type=int, default=5000, help='Port to use for the backend.')
+parser.add_argument('--frontend_port', type=int, default=8000, help='Port to use for the frontend.')
+
+
+args = parser.parse_args()
+args = parser.parse_args()
+
+# Check if docker is installed.
+try:
+    subprocess.check_call(['docker', '--version'])
+except:
+    raise Exception('Docker is not installed. Please install Docker to use this tool.')
+
+# Check if docker is running.
+try:
+    subprocess.check_call(['docker', 'ps'])
+except:
+    raise Exception('Docker is not running. Please start Docker to use this tool.')
+
+# Check if backend image is available.
+try:
+    subprocess.check_call(['docker', 'pull', BACKEND_IMAGE])
+except:
+    raise Exception('Could not pull backend image. Please check your internet connection.')
+
+if not args.no_frontend:
+    # Check if frontend image is available.
+    try:
+        subprocess.check_call(['docker', 'pull', FRONTEND_IMAGE])
+    except:
+        raise Exception('Could not pull frontend image. Please check your internet connection.')
+
+
+if args.memory:
+    memory = args.memory
+else:
+    total_memory_in_mb = psutil.virtual_memory().total / 1024 / 1024
+    suggested_memory = int(total_memory_in_mb * 0.8)
+    print(f'No memory specified. Using {suggested_memory} MB for the backend. You can modify this with the --memory argument.')
+
+
+
+
+
+# Start backend
+
+# something like:
+#docker run -p 80:80 -v "/Users/MyUserName/Desktop/myfile.jsonl.gz:/mnt/data/myfile.jsonl.gz" -e "DATA_FILE=/mnt/data/myfile.jsonl.gz" -e "MAX_MEM=8000" -e "CONFIG_JSON=config_public.json" theosanderson/taxonium_backend:master
+
+backend_command = ['docker', 'run', '-d', '-p', f'{args.backend_port}:80', '-v', f'"{args.jsonl_gz}:/mnt/data/data.jsonl.gz"', '-e', f'"DATA_FILE=/mnt/data/data.jsonl.gz"', '-e', f'"MAX_MEM={memory}"', '-e', f'"CONFIG_JSON=config_public.json"', BACKEND_IMAGE]
+
+print('Starting backend...')
+backend_process = subprocess.Popen(backend_command)
+backend_id = backend_process.stdout.read().decode('utf-8').strip()
+print(f'Backend started with ID {backend_id}.')
+print(f'Backend should appear on port {args.backend_port} in a few minutes.')
+
+# Start frontend
+if not args.no_frontend:
+    frontend_command = ['docker', 'run', '-d', '-p', f'{args.frontend_port}:80', FRONTEND_IMAGE]
+    print('Starting frontend...')
+    frontend_process = subprocess.Popen(frontend_command)
+    frontend_id = frontend_process.stdout.read().decode('utf-8').strip()
+    print(f'Frontend started with ID {frontend_id}.')
+    print(f'Frontend should appear on port {args.frontend_port} in a few minutes.')
+
+# Clean up
+def cleanup():
+    print('Cleaning up...')
+    if not args.no_frontend:
+        subprocess.check_call(['docker', 'kill', frontend_id])
+    subprocess.check_call(['docker', 'kill', backend_id])
+    print('Done.')
+
+atexit.register(cleanup)
+
+if args.no_frontend:
+    print(f'The backend should be running at http://localhost:{args.backend_port}.')
+else:
+    print(f'You should be able to access your tree at http://localhost:{args.frontend_port}/?backend=http://localhost:{args.backend_port} in a few minutes.')


### PR DESCRIPTION
This adds to taxoniumtools (in the next release, yet to be made) a `view_taxonium` command that uses docker to start a backend and a frontend from a local file. Still remaining is to allow the backend to automatically setup its config, as the frontend does.