### PR TITLE
Custom annotation files

### DIFF
--- a/taxonium_web_client/package.json
+++ b/taxonium_web_client/package.json
@@ -6,7 +6,7 @@
     "@craco/craco": "^6.1.2",
     "@fontsource/roboto": "^4.5.5",
     "@jbrowse/plugin-data-management": "^2.1.4",
-    "@jbrowse/react-linear-genome-view": "^2.1.2",
+    "@jbrowse/react-linear-genome-view": "^2.1.4",
     "@tailwindcss/forms": "^0.5.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/taxonium_web_client/package.json
+++ b/taxonium_web_client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@craco/craco": "^6.1.2",
     "@fontsource/roboto": "^4.5.5",
+    "@jbrowse/plugin-data-management": "^2.1.4",
     "@jbrowse/react-linear-genome-view": "^2.1.2",
     "@tailwindcss/forms": "^0.5.2",
     "@testing-library/jest-dom": "^5.11.4",

--- a/taxonium_web_client/src/App.css
+++ b/taxonium_web_client/src/App.css
@@ -73,9 +73,8 @@ input {
 
 button[data-testid="addTrackNextButton"] {
   background-color: #858585;
-
 }
 
-.MuiDialog-container > div > div > .MuiScopedCssBaseline-root  {
+.MuiDialog-container > div > div > .MuiScopedCssBaseline-root {
   padding: 15px;
 }

--- a/taxonium_web_client/src/App.css
+++ b/taxonium_web_client/src/App.css
@@ -8,7 +8,7 @@
 }
 
 /* JBrowse customization */
-.MuiPaper-root.MuiPaper-rounded {
+.MuiPaper-root.MuiPaper-rounded.MuiPaper-elevation {
   box-shadow: none !important;
   padding: 0px !important;
   margin: 0px !important;
@@ -69,4 +69,13 @@ input {
 .tooltipLink {
   color: #2563eb;
   text-decoration: underline;
+}
+
+button[data-testid="addTrackNextButton"] {
+  background-color: #858585;
+
+}
+
+.MuiDialog-container > div > div > .MuiScopedCssBaseline-root  {
+  padding: 15px;
 }

--- a/taxonium_web_client/src/Deck.jsx
+++ b/taxonium_web_client/src/Deck.jsx
@@ -19,6 +19,7 @@ import DeckSettingsModal from "./components/DeckSettingsModal";
 import { TreenomeButtons } from "./components/TreenomeButtons";
 import TreenomeModal from "./components/TreenomeModal";
 import FirefoxWarning from "./components/FirefoxWarning";
+import { JBrowseErrorBoundary } from "./components/JBrowseErrorBoundary";
 
 function Deck({
   data,
@@ -284,7 +285,12 @@ function Deck({
             }}
           >
             <span ref={jbrowseRef}>
-              <JBrowsePanel treenomeState={treenomeState} settings={settings} />
+              <JBrowseErrorBoundary>
+                <JBrowsePanel
+                  treenomeState={treenomeState}
+                  settings={settings}
+                />
+              </JBrowseErrorBoundary>
               <TreenomeModal
                 treenomeSettingsOpen={treenomeSettingsOpen}
                 setTreenomeSettingsOpen={setTreenomeSettingsOpen}

--- a/taxonium_web_client/src/Deck.jsx
+++ b/taxonium_web_client/src/Deck.jsx
@@ -16,6 +16,8 @@ import NodeHoverTip from "./components/NodeHoverTip";
 import TreenomeMutationHoverTip from "./components/TreenomeMutationHoverTip";
 import { DeckButtons } from "./components/DeckButtons";
 import DeckSettingsModal from "./components/DeckSettingsModal";
+import { TreenomeButtons } from "./components/TreenomeButtons";
+import TreenomeModal from "./components/TreenomeModal";
 import FirefoxWarning from "./components/FirefoxWarning";
 
 function Deck({
@@ -39,6 +41,7 @@ function Deck({
 }) {
   const snapshot = useSnapshot(deckRef);
   const [deckSettingsOpen, setDeckSettingsOpen] = useState(false);
+  const [treenomeSettingsOpen, setTreenomeSettingsOpen] = useState(false);
 
   //console.log("DATA is ", data);
   const no_data = !data.data || !data.data.nodes || !data.data.nodes.length;
@@ -83,7 +86,7 @@ function Deck({
         mouseDownPos.current &&
         Math.sqrt(
           Math.pow(mouseDownPos.current[0] - event.clientX, 2) +
-            Math.pow(mouseDownPos.current[1] - event.clientY, 2)
+          Math.pow(mouseDownPos.current[1] - event.clientY, 2)
         ) > pan_threshold
       ) {
         return false;
@@ -280,10 +283,27 @@ function Deck({
               zIndex: 1,
             }}
           >
+          
             <span ref={jbrowseRef}>
               <JBrowsePanel treenomeState={treenomeState} settings={settings} />
+              <TreenomeModal
+                treenomeSettingsOpen={treenomeSettingsOpen}
+                setTreenomeSettingsOpen={setTreenomeSettingsOpen}
+                settings={settings}
+              />
             </span>
           </div>
+          
+          <TreenomeButtons
+            loading={data.status === "loading"}
+            requestOpenSettings={() => {
+              console.log("opening")
+              console.log(treenomeSettingsOpen)
+
+              setTreenomeSettingsOpen(true)
+            }}
+            settings={settings}
+          />
         </View>
         <View id="main">
           <NodeHoverTip
@@ -312,6 +332,7 @@ function Deck({
             requestOpenSettings={() => setDeckSettingsOpen(true)}
             settings={settings}
           />
+
         </View>
       </DeckGL>
     </div>

--- a/taxonium_web_client/src/Deck.jsx
+++ b/taxonium_web_client/src/Deck.jsx
@@ -86,7 +86,7 @@ function Deck({
         mouseDownPos.current &&
         Math.sqrt(
           Math.pow(mouseDownPos.current[0] - event.clientX, 2) +
-          Math.pow(mouseDownPos.current[1] - event.clientY, 2)
+            Math.pow(mouseDownPos.current[1] - event.clientY, 2)
         ) > pan_threshold
       ) {
         return false;
@@ -283,7 +283,6 @@ function Deck({
               zIndex: 1,
             }}
           >
-          
             <span ref={jbrowseRef}>
               <JBrowsePanel treenomeState={treenomeState} settings={settings} />
               <TreenomeModal
@@ -293,14 +292,14 @@ function Deck({
               />
             </span>
           </div>
-          
+
           <TreenomeButtons
             loading={data.status === "loading"}
             requestOpenSettings={() => {
-              console.log("opening")
-              console.log(treenomeSettingsOpen)
+              console.log("opening");
+              console.log(treenomeSettingsOpen);
 
-              setTreenomeSettingsOpen(true)
+              setTreenomeSettingsOpen(true);
             }}
             settings={settings}
           />
@@ -332,7 +331,6 @@ function Deck({
             requestOpenSettings={() => setDeckSettingsOpen(true)}
             settings={settings}
           />
-
         </View>
       </DeckGL>
     </div>

--- a/taxonium_web_client/src/components/JBrowseErrorBoundary.jsx
+++ b/taxonium_web_client/src/components/JBrowseErrorBoundary.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { toast } from "react-hot-toast";
+
+export class JBrowseErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { fileError: false, otherError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    if (
+      error.message === "invalid SceneGraph arguments" ||
+      error.message === "Invalid array length"
+    ) {
+      return { fileError: true };
+    }
+    return { otherError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    if (
+      error.message === "invalid SceneGraph arguments" ||
+      error.message === "Invalid array length"
+    ) {
+      toast.error(
+        "Error displaying track. Please make sure your file is well-formatted (e.g., validated with https://github.com/EBIvariation/vcf-validator)."
+      );
+    }
+  }
+
+  render() {
+    return this.state.fileError || !this.state.otherError
+      ? this.props.children
+      : "";
+  }
+}

--- a/taxonium_web_client/src/components/JBrowsePanel.jsx
+++ b/taxonium_web_client/src/components/JBrowsePanel.jsx
@@ -11,7 +11,7 @@ import { AssemblyManager } from "@jbrowse/plugin-data-management";
 import { protect, unprotect } from "mobx-state-tree";
 
 function JBrowsePanel(props) {
-  const treenomeAnnotations = useTreenomeAnnotations(props.settings)
+  const treenomeAnnotations = useTreenomeAnnotations(props.settings);
 
   const assembly = useMemo(() => {
     return {
@@ -46,133 +46,133 @@ function JBrowsePanel(props) {
     props.settings.chromosomeName,
   ]);
 
-
   const [userTracks, setUserTracks] = React.useState([]);
 
   const tracks = useMemo(() => {
-    const covTracks = [{
-      type: "FeatureTrack",
-      trackId: "nextstrain-annotations",
-      name: "Genes",
-      assemblyNames: [props.settings.chromosomeName],
-      category: [],
-      adapter: {
-        type: "FromConfigAdapter",
-        features: [
+    const covTracks = [
+      {
+        type: "FeatureTrack",
+        trackId: "nextstrain-annotations",
+        name: "Genes",
+        assemblyNames: [props.settings.chromosomeName],
+        category: [],
+        adapter: {
+          type: "FromConfigAdapter",
+          features: [
+            {
+              refName: props.settings.chromosomeName,
+              name: "E",
+              uniqueId: 4,
+              start: 26244,
+              end: 26472,
+              fill: "#D9AD3D",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "M",
+              uniqueId: 5,
+              start: 26522,
+              end: 27191,
+              fill: "#5097BA",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "N",
+              uniqueId: 10,
+              start: 28273,
+              end: 29533,
+              fill: "#E67030",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "Orf1a",
+              uniqueId: 0,
+              start: 265,
+              end: 13468,
+              fill: "#8EBC66",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "ORF1b",
+              uniqueId: 1,
+              start: 13467,
+              end: 21555,
+              fill: "#E59637",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "ORF3a",
+              uniqueId: 3,
+              start: 25392,
+              end: 26220,
+              fill: "#AABD52",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "ORF6",
+              uniqueId: 6,
+              start: 27201,
+              end: 27387,
+              fill: "#DF4327",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "ORF7a",
+              uniqueId: 7,
+              start: 27393,
+              end: 27759,
+              fill: "#C4B945",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "ORF7b",
+              uniqueId: 8,
+              start: 27755,
+              end: 27887,
+              fill: "#75B681",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "ORF8",
+              uniqueId: 9,
+              start: 27893,
+              end: 28259,
+              fill: "#60AA9E",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "ORF9b",
+              uniqueId: 11,
+              start: 28283,
+              end: 28577,
+              fill: "#D9AD3D",
+            },
+            {
+              refName: props.settings.chromosomeName,
+              name: "S",
+              uniqueId: 2,
+              start: 21562,
+              end: 25384,
+              fill: "#5097BA",
+            },
+          ],
+        },
+        displays: [
           {
-            refName: props.settings.chromosomeName,
-            name: "E",
-            uniqueId: 4,
-            start: 26244,
-            end: 26472,
-            fill: "#D9AD3D",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "M",
-            uniqueId: 5,
-            start: 26522,
-            end: 27191,
-            fill: "#5097BA",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "N",
-            uniqueId: 10,
-            start: 28273,
-            end: 29533,
-            fill: "#E67030",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "Orf1a",
-            uniqueId: 0,
-            start: 265,
-            end: 13468,
-            fill: "#8EBC66",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "ORF1b",
-            uniqueId: 1,
-            start: 13467,
-            end: 21555,
-            fill: "#E59637",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "ORF3a",
-            uniqueId: 3,
-            start: 25392,
-            end: 26220,
-            fill: "#AABD52",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "ORF6",
-            uniqueId: 6,
-            start: 27201,
-            end: 27387,
-            fill: "#DF4327",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "ORF7a",
-            uniqueId: 7,
-            start: 27393,
-            end: 27759,
-            fill: "#C4B945",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "ORF7b",
-            uniqueId: 8,
-            start: 27755,
-            end: 27887,
-            fill: "#75B681",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "ORF8",
-            uniqueId: 9,
-            start: 27893,
-            end: 28259,
-            fill: "#60AA9E",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "ORF9b",
-            uniqueId: 11,
-            start: 28283,
-            end: 28577,
-            fill: "#D9AD3D",
-          },
-          {
-            refName: props.settings.chromosomeName,
-            name: "S",
-            uniqueId: 2,
-            start: 21562,
-            end: 25384,
-            fill: "#5097BA",
+            type: "LinearBasicDisplay",
+            displayId: "nextstrain-color-display",
+            renderer: {
+              type: "SvgFeatureRenderer",
+              color1: "jexl:get(feature,'fill') || 'black'",
+            },
           },
         ],
       },
-      displays: [
-        {
-          type: "LinearBasicDisplay",
-          displayId: "nextstrain-color-display",
-          renderer: {
-            type: "SvgFeatureRenderer",
-            color1: "jexl:get(feature,'fill') || 'black'",
-          },
-        },
-      ],
-    },
-    ...treenomeAnnotations.json
-  ];
-  return userTracks.concat(covTracks);
+      ...treenomeAnnotations.json,
+    ];
+    return userTracks.concat(covTracks);
   }, [props.settings.chromosomeName, treenomeAnnotations.json, userTracks]);
-      
+
   const defaultSession = useMemo(() => {
     return {
       name: "Default",
@@ -182,18 +182,18 @@ function JBrowsePanel(props) {
         hideCloseButton: true,
         tracks: props.settings.isCov2Tree
           ? [
-            {
-              type: "FeatureTrack",
-              configuration: "nextstrain-annotations",
-              displays: [
-                {
-                  type: "LinearBasicDisplay",
-                  configuration: "nextstrain-color-display",
-                  height: 60,
-                },
-              ],
-            },
-          ]
+              {
+                type: "FeatureTrack",
+                configuration: "nextstrain-annotations",
+                displays: [
+                  {
+                    type: "LinearBasicDisplay",
+                    configuration: "nextstrain-color-display",
+                    height: 60,
+                  },
+                ],
+              },
+            ]
           : [],
       },
     };
@@ -230,8 +230,8 @@ function JBrowsePanel(props) {
         location: props.settings.isCov2Tree
           ? `${props.settings.chromosomeName}:0-29903`
           : props.settings.chromosomeName +
-          ":0-" +
-          props.treenomeState.genomeSize,
+            ":0-" +
+            props.treenomeState.genomeSize,
         defaultSession: defaultSession,
         ...theme,
         onChange: (patch) => {
@@ -254,16 +254,22 @@ function JBrowsePanel(props) {
           }
         },
       }),
-    [assembly, props.settings.isCov2Tree, props.settings.chromosomeName, tracks, defaultSession, theme]
+    [
+      assembly,
+      props.settings.isCov2Tree,
+      props.settings.chromosomeName,
+      tracks,
+      defaultSession,
+      theme,
+    ]
   );
-
 
   useEffect(() => {
     if (state && state.session && state.session.view) {
       const widget = state.session.addWidget(
-        'AddTrackWidget',
-        'addTrackWidget',
-        { view: state.session.view.id, },
+        "AddTrackWidget",
+        "addTrackWidget",
+        { view: state.session.view.id }
       );
       // AddTrackWidget calls session.addTrackConf, which
       // doesn't appear to be defined in the session object
@@ -271,7 +277,7 @@ function JBrowsePanel(props) {
       unprotect(state);
       state.session.addTrackConf = (trackConf) => {
         setUserTracks(userTracks.concat(trackConf));
-      }
+      };
       protect(state);
     }
   }, [state, userTracks]);
@@ -283,10 +289,10 @@ function JBrowsePanel(props) {
     const v = state.session.view;
     v.navToLocString(
       props.settings.chromosomeName +
-      ":" +
-      props.treenomeState.ntBoundsExt[0] +
-      ".." +
-      props.treenomeState.ntBoundsExt[1]
+        ":" +
+        props.treenomeState.ntBoundsExt[0] +
+        ".." +
+        props.treenomeState.ntBoundsExt[1]
     );
     props.treenomeState.setNtBoundsExt(null);
   }, [props.settings.chromosomeName, props.treenomeState, state.session.view]);
@@ -310,7 +316,7 @@ function JBrowsePanel(props) {
     }
   }, [props.treenomeState, state.session.view]);
 
-  return <JBrowseLinearGenomeView viewState={state} />
+  return <JBrowseLinearGenomeView viewState={state} />;
 }
 
 export default JBrowsePanel;

--- a/taxonium_web_client/src/components/JBrowsePanel.jsx
+++ b/taxonium_web_client/src/components/JBrowsePanel.jsx
@@ -1,30 +1,32 @@
 import React, { useMemo, useEffect } from "react";
 import "@fontsource/roboto";
+import "@jbrowse/plugin-data-management";
 import "../App.css";
 import useTreenomeAnnotations from "../hooks/useTreenomeAnnotations";
-
 import {
   createViewState,
   JBrowseLinearGenomeView,
 } from "@jbrowse/react-linear-genome-view";
+import { AssemblyManager } from "@jbrowse/plugin-data-management";
+import { protect, unprotect } from "mobx-state-tree";
 
 function JBrowsePanel(props) {
-  const treenomeAnnotations = useTreenomeAnnotations();
+  const treenomeAnnotations = useTreenomeAnnotations(props.settings)
 
   const assembly = useMemo(() => {
     return {
-      name: props.treenomeState.chromosomeName
-        ? props.treenomeState.chromosomeName
+      name: props.settings.chromosomeName
+        ? props.settings.chromosomeName
         : "chromosome",
       sequence: {
         type: "ReferenceSequenceTrack",
-        trackId: props.treenomeState.chromosomeName + "-ReferenceSequenceTrack",
+        trackId: props.settings.chromosomeName + "-ReferenceSequenceTrack",
         adapter: {
           type: "FromConfigSequenceAdapter",
           features: [
             {
-              refName: props.treenomeState.chromosomeName,
-              uniqueId: props.treenomeState.chromosomeName,
+              refName: props.settings.chromosomeName,
+              uniqueId: props.settings.chromosomeName,
               start: 0,
               end:
                 props.treenomeState.genomeSize > 0
@@ -41,133 +43,136 @@ function JBrowsePanel(props) {
   }, [
     props.treenomeState.genome,
     props.treenomeState.genomeSize,
-    props.treenomeState.chromosomeName,
+    props.settings.chromosomeName,
   ]);
 
+
+  const [userTracks, setUserTracks] = React.useState([]);
+
   const tracks = useMemo(() => {
-    return [
-      {
-        type: "FeatureTrack",
-        trackId: "nextstrain-annotations",
-        name: "Genes",
-        assemblyNames: ["NC_045512v2"],
-        category: [],
-        adapter: {
-          type: "FromConfigAdapter",
-          features: [
-            {
-              refName: "NC_045512v2",
-              name: "E",
-              uniqueId: 4,
-              start: 26244,
-              end: 26472,
-              fill: "#D9AD3D",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "M",
-              uniqueId: 5,
-              start: 26522,
-              end: 27191,
-              fill: "#5097BA",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "N",
-              uniqueId: 10,
-              start: 28273,
-              end: 29533,
-              fill: "#E67030",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "Orf1a",
-              uniqueId: 0,
-              start: 265,
-              end: 13468,
-              fill: "#8EBC66",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "ORF1b",
-              uniqueId: 1,
-              start: 13467,
-              end: 21555,
-              fill: "#E59637",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "ORF3a",
-              uniqueId: 3,
-              start: 25392,
-              end: 26220,
-              fill: "#AABD52",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "ORF6",
-              uniqueId: 6,
-              start: 27201,
-              end: 27387,
-              fill: "#DF4327",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "ORF7a",
-              uniqueId: 7,
-              start: 27393,
-              end: 27759,
-              fill: "#C4B945",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "ORF7b",
-              uniqueId: 8,
-              start: 27755,
-              end: 27887,
-              fill: "#75B681",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "ORF8",
-              uniqueId: 9,
-              start: 27893,
-              end: 28259,
-              fill: "#60AA9E",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "ORF9b",
-              uniqueId: 11,
-              start: 28283,
-              end: 28577,
-              fill: "#D9AD3D",
-            },
-            {
-              refName: "NC_045512v2",
-              name: "S",
-              uniqueId: 2,
-              start: 21562,
-              end: 25384,
-              fill: "#5097BA",
-            },
-          ],
-        },
-        displays: [
+    const covTracks = [{
+      type: "FeatureTrack",
+      trackId: "nextstrain-annotations",
+      name: "Genes",
+      assemblyNames: [props.settings.chromosomeName],
+      category: [],
+      adapter: {
+        type: "FromConfigAdapter",
+        features: [
           {
-            type: "LinearBasicDisplay",
-            displayId: "nextstrain-color-display",
-            renderer: {
-              type: "SvgFeatureRenderer",
-              color1: "jexl:get(feature,'fill') || 'black'",
-            },
+            refName: props.settings.chromosomeName,
+            name: "E",
+            uniqueId: 4,
+            start: 26244,
+            end: 26472,
+            fill: "#D9AD3D",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "M",
+            uniqueId: 5,
+            start: 26522,
+            end: 27191,
+            fill: "#5097BA",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "N",
+            uniqueId: 10,
+            start: 28273,
+            end: 29533,
+            fill: "#E67030",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "Orf1a",
+            uniqueId: 0,
+            start: 265,
+            end: 13468,
+            fill: "#8EBC66",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "ORF1b",
+            uniqueId: 1,
+            start: 13467,
+            end: 21555,
+            fill: "#E59637",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "ORF3a",
+            uniqueId: 3,
+            start: 25392,
+            end: 26220,
+            fill: "#AABD52",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "ORF6",
+            uniqueId: 6,
+            start: 27201,
+            end: 27387,
+            fill: "#DF4327",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "ORF7a",
+            uniqueId: 7,
+            start: 27393,
+            end: 27759,
+            fill: "#C4B945",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "ORF7b",
+            uniqueId: 8,
+            start: 27755,
+            end: 27887,
+            fill: "#75B681",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "ORF8",
+            uniqueId: 9,
+            start: 27893,
+            end: 28259,
+            fill: "#60AA9E",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "ORF9b",
+            uniqueId: 11,
+            start: 28283,
+            end: 28577,
+            fill: "#D9AD3D",
+          },
+          {
+            refName: props.settings.chromosomeName,
+            name: "S",
+            uniqueId: 2,
+            start: 21562,
+            end: 25384,
+            fill: "#5097BA",
           },
         ],
       },
-      ...treenomeAnnotations.json,
-    ];
-  }, [treenomeAnnotations.json]);
-
+      displays: [
+        {
+          type: "LinearBasicDisplay",
+          displayId: "nextstrain-color-display",
+          renderer: {
+            type: "SvgFeatureRenderer",
+            color1: "jexl:get(feature,'fill') || 'black'",
+          },
+        },
+      ],
+    },
+    ...treenomeAnnotations.json
+  ];
+  return userTracks.concat(covTracks);
+  }, [props.settings.chromosomeName, treenomeAnnotations.json, userTracks]);
+      
   const defaultSession = useMemo(() => {
     return {
       name: "Default",
@@ -177,18 +182,18 @@ function JBrowsePanel(props) {
         hideCloseButton: true,
         tracks: props.settings.isCov2Tree
           ? [
-              {
-                type: "FeatureTrack",
-                configuration: "nextstrain-annotations",
-                displays: [
-                  {
-                    type: "LinearBasicDisplay",
-                    configuration: "nextstrain-color-display",
-                    height: 60,
-                  },
-                ],
-              },
-            ]
+            {
+              type: "FeatureTrack",
+              configuration: "nextstrain-annotations",
+              displays: [
+                {
+                  type: "LinearBasicDisplay",
+                  configuration: "nextstrain-color-display",
+                  height: 60,
+                },
+              ],
+            },
+          ]
           : [],
       },
     };
@@ -203,7 +208,7 @@ function JBrowsePanel(props) {
               main: "#555e6c",
             },
             secondary: {
-              main: "#2463eb",
+              main: "#aaa",
             },
             tertiary: {
               main: "#bcbcbc",
@@ -223,10 +228,10 @@ function JBrowsePanel(props) {
         assembly,
         tracks: props.settings.isCov2Tree ? tracks : undefined,
         location: props.settings.isCov2Tree
-          ? "NC_045512v2:0-29903"
-          : props.treenomeState.chromosomeName +
-            ":0-" +
-            props.treenomeState.genomeSize,
+          ? `${props.settings.chromosomeName}:0-29903`
+          : props.settings.chromosomeName +
+          ":0-" +
+          props.treenomeState.genomeSize,
         defaultSession: defaultSession,
         ...theme,
         onChange: (patch) => {
@@ -249,9 +254,27 @@ function JBrowsePanel(props) {
           }
         },
       }),
-    [assembly, tracks, props.settings.isCov2Tree, defaultSession, theme]
+    [assembly, props.settings.isCov2Tree, props.settings.chromosomeName, tracks, defaultSession, theme]
   );
-  // TODO: Adding treenomState as dependency above breaks things
+
+
+  useEffect(() => {
+    if (state && state.session && state.session.view) {
+      const widget = state.session.addWidget(
+        'AddTrackWidget',
+        'addTrackWidget',
+        { view: state.session.view.id, },
+      );
+      // AddTrackWidget calls session.addTrackConf, which
+      // doesn't appear to be defined in the session object
+      // for some reason. So we add it here.
+      unprotect(state);
+      state.session.addTrackConf = (trackConf) => {
+        setUserTracks(userTracks.concat(trackConf));
+      }
+      protect(state);
+    }
+  }, [state, userTracks]);
 
   useEffect(() => {
     if (!props.treenomeState.ntBoundsExt) {
@@ -259,14 +282,14 @@ function JBrowsePanel(props) {
     }
     const v = state.session.view;
     v.navToLocString(
-      props.treenomeState.chromosomeName +
-        ":" +
-        props.treenomeState.ntBoundsExt[0] +
-        ".." +
-        props.treenomeState.ntBoundsExt[1]
+      props.settings.chromosomeName +
+      ":" +
+      props.treenomeState.ntBoundsExt[0] +
+      ".." +
+      props.treenomeState.ntBoundsExt[1]
     );
     props.treenomeState.setNtBoundsExt(null);
-  }, [props.treenomeState, state.session.view]);
+  }, [props.settings.chromosomeName, props.treenomeState, state.session.view]);
 
   useEffect(() => {
     const v = state.session.view;
@@ -287,7 +310,7 @@ function JBrowsePanel(props) {
     }
   }, [props.treenomeState, state.session.view]);
 
-  return <JBrowseLinearGenomeView viewState={state} />;
+  return <JBrowseLinearGenomeView viewState={state} />
 }
 
 export default JBrowsePanel;

--- a/taxonium_web_client/src/components/SearchPanel.jsx
+++ b/taxonium_web_client/src/components/SearchPanel.jsx
@@ -305,14 +305,7 @@ function SearchPanel({
                 className="m-3 inline-block"
                 checked={settings.treenomeEnabled}
                 onChange={(event) => {
-                  console.log(settings.treenomeEnabled);
                   settings.setTreenomeEnabled(!settings.treenomeEnabled);
-
-                  // view.setViewState({
-                  //   ...view.viewState,
-                  //  "browser-main": { zoom: -2, target: [500, 1000] },
-                  // "browser-axis": { zoom: -2, target: [0, 1000] },
-                  // });
                 }}
               />
               <button

--- a/taxonium_web_client/src/components/TreenomeButtons.jsx
+++ b/taxonium_web_client/src/components/TreenomeButtons.jsx
@@ -1,55 +1,51 @@
 import {
-    BiZoomIn,
-    BiZoomOut,
-    BiCamera,
-    BiMoveVertical,
-    BiMoveHorizontal,
+  BiZoomIn,
+  BiZoomOut,
+  BiCamera,
+  BiMoveVertical,
+  BiMoveHorizontal,
 } from "react-icons/bi";
 
 import { TiZoom, TiCog } from "react-icons/ti";
 import { ClipLoader } from "react-spinners";
 
 const TaxButton = ({ children, onClick, title }) => {
-    return (
-        <button
-            className=" w-12 h-10 bg-gray-100 p-1 rounded border-gray-300 text-gray-700  opacity-70  hover:opacity-100 mr-1 z-50 mt-auto mb-1
+  return (
+    <button
+      className=" w-12 h-10 bg-gray-100 p-1 rounded border-gray-300 text-gray-700  opacity-70  hover:opacity-100 mr-1 z-50 mt-auto mb-1
         shadow-md "
-            onClick={onClick}
-            title={title}
-        >
-            {children}
-        </button>
-    );
+      onClick={onClick}
+      title={title}
+    >
+      {children}
+    </button>
+  );
 };
 
-export const TreenomeButtons = ({
-    loading,
-    requestOpenSettings,
-    settings,
-}) => {
-    return (
-        <div
-            style={{
-                position: "absolute",
-                right: "0.2em",
-                bottom: "0.2em",
-                zIndex: 10,
-            }}
-            className="flex justify-end"
-        >
-            {loading && (
-                <div className="mr-4 mt-auto inline-block">
-                    <ClipLoader size={24} color="#444444" />
-                </div>
-            )}
-            <TaxButton
-                onClick={() => {
-                    requestOpenSettings();
-                }}
-                title="Settings"
-            >
-                <TiCog className="mx-auto w-5 h-5 inline-block" />
-            </TaxButton>
+export const TreenomeButtons = ({ loading, requestOpenSettings, settings }) => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        right: "0.2em",
+        bottom: "0.2em",
+        zIndex: 10,
+      }}
+      className="flex justify-end"
+    >
+      {loading && (
+        <div className="mr-4 mt-auto inline-block">
+          <ClipLoader size={24} color="#444444" />
         </div>
-    )
+      )}
+      <TaxButton
+        onClick={() => {
+          requestOpenSettings();
+        }}
+        title="Settings"
+      >
+        <TiCog className="mx-auto w-5 h-5 inline-block" />
+      </TaxButton>
+    </div>
+  );
 };

--- a/taxonium_web_client/src/components/TreenomeButtons.jsx
+++ b/taxonium_web_client/src/components/TreenomeButtons.jsx
@@ -1,0 +1,55 @@
+import {
+    BiZoomIn,
+    BiZoomOut,
+    BiCamera,
+    BiMoveVertical,
+    BiMoveHorizontal,
+} from "react-icons/bi";
+
+import { TiZoom, TiCog } from "react-icons/ti";
+import { ClipLoader } from "react-spinners";
+
+const TaxButton = ({ children, onClick, title }) => {
+    return (
+        <button
+            className=" w-12 h-10 bg-gray-100 p-1 rounded border-gray-300 text-gray-700  opacity-70  hover:opacity-100 mr-1 z-50 mt-auto mb-1
+        shadow-md "
+            onClick={onClick}
+            title={title}
+        >
+            {children}
+        </button>
+    );
+};
+
+export const TreenomeButtons = ({
+    loading,
+    requestOpenSettings,
+    settings,
+}) => {
+    return (
+        <div
+            style={{
+                position: "absolute",
+                right: "0.2em",
+                bottom: "0.2em",
+                zIndex: 10,
+            }}
+            className="flex justify-end"
+        >
+            {loading && (
+                <div className="mr-4 mt-auto inline-block">
+                    <ClipLoader size={24} color="#444444" />
+                </div>
+            )}
+            <TaxButton
+                onClick={() => {
+                    requestOpenSettings();
+                }}
+                title="Settings"
+            >
+                <TiCog className="mx-auto w-5 h-5 inline-block" />
+            </TaxButton>
+        </div>
+    )
+};

--- a/taxonium_web_client/src/components/TreenomeModal.jsx
+++ b/taxonium_web_client/src/components/TreenomeModal.jsx
@@ -1,0 +1,57 @@
+import Modal from "react-modal";
+import { useState } from "react";
+const settingsModalStyle = {
+    content: {
+        top: "50%",
+        left: "50%",
+        right: "auto",
+        bottom: "auto",
+        marginRight: "-50%",
+        transform: "translate(-50%, -50%)",
+        //width: '50%',
+        backgroundColor: "#fafafa",
+        maxWidth: "500px",
+    },
+};
+
+
+
+const TreenomeModal = ({
+    treenomeSettingsOpen,
+    setTreenomeSettingsOpen,
+    settings
+}) => {
+    const [inputChromosome, setInputChromosome] = useState(settings.chromosomeName);
+    return (
+        <Modal
+            isOpen={treenomeSettingsOpen}
+            style={settingsModalStyle}
+            onRequestClose={() => {
+                settings.setChromosomeName(inputChromosome);
+                setTreenomeSettingsOpen(false);
+            }}
+        >
+            <h2 className="font-medium mb-3">Treenome Settings</h2>
+            <div>
+                <label>
+                    Reference chromosome name{" "}
+                    <input
+                        type="text"
+                        value={inputChromosome}
+                        onChange={(e) => {
+                            setInputChromosome(e.target.value);
+                        }}
+                        className="border py-1 px-1 text-grey-darkest text-sm"
+                    />
+                </label>
+                <br/>
+                <span style={{fontSize: "10pt"}}><em><strong>Loaded annotations must match this name.</strong><br/>
+                    {settings.isCov2Tree
+                    ? "Cov2Tree uses the NC_045512v2 / MN908947.3 / WuhCor1 reference assembly. If you change this name, make sure your annotations target the same assembly."
+                    : ""
+                    }</em></span>
+            </div>
+        </Modal>
+    );
+};
+export default TreenomeModal;

--- a/taxonium_web_client/src/components/TreenomeModal.jsx
+++ b/taxonium_web_client/src/components/TreenomeModal.jsx
@@ -1,57 +1,61 @@
 import Modal from "react-modal";
 import { useState } from "react";
 const settingsModalStyle = {
-    content: {
-        top: "50%",
-        left: "50%",
-        right: "auto",
-        bottom: "auto",
-        marginRight: "-50%",
-        transform: "translate(-50%, -50%)",
-        //width: '50%',
-        backgroundColor: "#fafafa",
-        maxWidth: "500px",
-    },
+  content: {
+    top: "50%",
+    left: "50%",
+    right: "auto",
+    bottom: "auto",
+    marginRight: "-50%",
+    transform: "translate(-50%, -50%)",
+    //width: '50%',
+    backgroundColor: "#fafafa",
+    maxWidth: "500px",
+  },
 };
 
-
-
 const TreenomeModal = ({
-    treenomeSettingsOpen,
-    setTreenomeSettingsOpen,
-    settings
+  treenomeSettingsOpen,
+  setTreenomeSettingsOpen,
+  settings,
 }) => {
-    const [inputChromosome, setInputChromosome] = useState(settings.chromosomeName);
-    return (
-        <Modal
-            isOpen={treenomeSettingsOpen}
-            style={settingsModalStyle}
-            onRequestClose={() => {
-                settings.setChromosomeName(inputChromosome);
-                setTreenomeSettingsOpen(false);
+  const [inputChromosome, setInputChromosome] = useState(
+    settings.chromosomeName
+  );
+  return (
+    <Modal
+      isOpen={treenomeSettingsOpen}
+      style={settingsModalStyle}
+      onRequestClose={() => {
+        settings.setChromosomeName(inputChromosome);
+        setTreenomeSettingsOpen(false);
+      }}
+    >
+      <h2 className="font-medium mb-3">Treenome Settings</h2>
+      <div>
+        <label>
+          Reference chromosome name{" "}
+          <input
+            type="text"
+            value={inputChromosome}
+            onChange={(e) => {
+              setInputChromosome(e.target.value);
             }}
-        >
-            <h2 className="font-medium mb-3">Treenome Settings</h2>
-            <div>
-                <label>
-                    Reference chromosome name{" "}
-                    <input
-                        type="text"
-                        value={inputChromosome}
-                        onChange={(e) => {
-                            setInputChromosome(e.target.value);
-                        }}
-                        className="border py-1 px-1 text-grey-darkest text-sm"
-                    />
-                </label>
-                <br/>
-                <span style={{fontSize: "10pt"}}><em><strong>Loaded annotations must match this name.</strong><br/>
-                    {settings.isCov2Tree
-                    ? "Cov2Tree uses the NC_045512v2 / MN908947.3 / WuhCor1 reference assembly. If you change this name, make sure your annotations target the same assembly."
-                    : ""
-                    }</em></span>
-            </div>
-        </Modal>
-    );
+            className="border py-1 px-1 text-grey-darkest text-sm"
+          />
+        </label>
+        <br />
+        <span style={{ fontSize: "10pt" }}>
+          <em>
+            <strong>Loaded annotations must match this name.</strong>
+            <br />
+            {settings.isCov2Tree
+              ? "Cov2Tree uses the NC_045512v2 / MN908947.3 / WuhCor1 reference assembly. If you change this name, make sure your annotations target the same assembly."
+              : ""}
+          </em>
+        </span>
+      </div>
+    </Modal>
+  );
 };
 export default TreenomeModal;

--- a/taxonium_web_client/src/hooks/useSettings.js
+++ b/taxonium_web_client/src/hooks/useSettings.js
@@ -83,12 +83,15 @@ export const useSettings = ({ query, updateQuery }) => {
     );
   };
 
+  const [chromosomeName, setChromosomeName] = useState("chromosome");
   const [isCov2Tree, setIsCov2Tree] = useState(false);
   useEffect(() => {
     if (window.location.href.includes("cov2tree.org")) {
       setIsCov2Tree(true);
+      setChromosomeName("NC_045512v2");
     }
   }, []);
+
 
   return {
     minimapEnabled,
@@ -108,5 +111,7 @@ export const useSettings = ({ query, updateQuery }) => {
     setMaxCladeTexts,
     miniMutationsMenu,
     isCov2Tree,
+    chromosomeName,
+    setChromosomeName,
   };
 };

--- a/taxonium_web_client/src/hooks/useSettings.js
+++ b/taxonium_web_client/src/hooks/useSettings.js
@@ -92,7 +92,6 @@ export const useSettings = ({ query, updateQuery }) => {
     }
   }, []);
 
-
   return {
     minimapEnabled,
     treenomeEnabled,

--- a/taxonium_web_client/src/hooks/useTreenomeAnnotations.js
+++ b/taxonium_web_client/src/hooks/useTreenomeAnnotations.js
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-const useTreenomeAnnotations = () => {
+const useTreenomeAnnotations = (settings) => {
   const [trackList, setTrackList] = useState([]);
   const baseUrl = "https://hgdownload.soe.ucsc.edu";
 
@@ -18,7 +18,10 @@ const useTreenomeAnnotations = () => {
     getTrackList();
   }, []);
 
-  const getJson = (track, key, name, category) => {
+
+  const getJson = useCallback((track, key, name, category) => {
+    console.log("in here")
+
     const url = track.bigDataUrl;
     if (!url) {
       return null;
@@ -31,7 +34,7 @@ const useTreenomeAnnotations = () => {
     const output = {
       trackId: key,
       name: name,
-      assemblyNames: ["NC_045512v2"],
+      assemblyNames: [settings.chromosomeName],
       category: category,
     };
     if (ext === "bb") {
@@ -54,7 +57,7 @@ const useTreenomeAnnotations = () => {
       };
     }
     return output;
-  };
+  }, [settings.chromosomeName]);
 
   const json = useMemo(() => {
     let allJson = [];
@@ -68,7 +71,7 @@ const useTreenomeAnnotations = () => {
             continue;
           }
           childJson = getJson(child, childKey, `${child.longLabel}`, [
-            "Composite UCSC Tracks",
+            "UCSC Tracks (Composite)",
             track.longLabel,
           ]);
           if (childJson) {
@@ -82,7 +85,7 @@ const useTreenomeAnnotations = () => {
       }
     }
     return allJson;
-  }, [trackList]);
+  }, [getJson, trackList.wuhCor1]);
 
   const output = useMemo(() => {
     return { json };

--- a/taxonium_web_client/src/hooks/useTreenomeAnnotations.js
+++ b/taxonium_web_client/src/hooks/useTreenomeAnnotations.js
@@ -20,8 +20,6 @@ const useTreenomeAnnotations = (settings) => {
 
   const getJson = useCallback(
     (track, key, name, category) => {
-      console.log("in here");
-
       const url = track.bigDataUrl;
       if (!url) {
         return null;

--- a/taxonium_web_client/src/hooks/useTreenomeAnnotations.js
+++ b/taxonium_web_client/src/hooks/useTreenomeAnnotations.js
@@ -18,46 +18,48 @@ const useTreenomeAnnotations = (settings) => {
     getTrackList();
   }, []);
 
+  const getJson = useCallback(
+    (track, key, name, category) => {
+      console.log("in here");
 
-  const getJson = useCallback((track, key, name, category) => {
-    console.log("in here")
-
-    const url = track.bigDataUrl;
-    if (!url) {
-      return null;
-    }
-    const ext = url.slice(-2);
-    if (ext !== "bb" && ext !== "bw") {
-      return null;
-    }
-    const fullUrl = `${baseUrl}${url}`;
-    const output = {
-      trackId: key,
-      name: name,
-      assemblyNames: [settings.chromosomeName],
-      category: category,
-    };
-    if (ext === "bb") {
-      output.type = "FeatureTrack";
-      output.adapter = {
-        type: "BigBedAdapter",
-        bigBedLocation: {
-          uri: fullUrl,
-          locationType: "UriLocation",
-        },
+      const url = track.bigDataUrl;
+      if (!url) {
+        return null;
+      }
+      const ext = url.slice(-2);
+      if (ext !== "bb" && ext !== "bw") {
+        return null;
+      }
+      const fullUrl = `${baseUrl}${url}`;
+      const output = {
+        trackId: key,
+        name: name,
+        assemblyNames: [settings.chromosomeName],
+        category: category,
       };
-    } else if (ext === "bw") {
-      output.type = "QuantitativeTrack";
-      output.adapter = {
-        type: "BigWigAdapter",
-        bigWigLocation: {
-          uri: fullUrl,
-          locationType: "UriLocation",
-        },
-      };
-    }
-    return output;
-  }, [settings.chromosomeName]);
+      if (ext === "bb") {
+        output.type = "FeatureTrack";
+        output.adapter = {
+          type: "BigBedAdapter",
+          bigBedLocation: {
+            uri: fullUrl,
+            locationType: "UriLocation",
+          },
+        };
+      } else if (ext === "bw") {
+        output.type = "QuantitativeTrack";
+        output.adapter = {
+          type: "BigWigAdapter",
+          bigWigLocation: {
+            uri: fullUrl,
+            locationType: "UriLocation",
+          },
+        };
+      }
+      return output;
+    },
+    [settings.chromosomeName]
+  );
 
   const json = useMemo(() => {
     let allJson = [];

--- a/taxonium_web_client/src/hooks/useTreenomeState.js
+++ b/taxonium_web_client/src/hooks/useTreenomeState.js
@@ -10,7 +10,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
   const [genomeSize, setGenomeSize] = useState(0);
   const [genome, setGenome] = useState(null);
 
-
   useEffect(() => {
     if (
       (genomeSize && genomeSize > 0) ||

--- a/taxonium_web_client/src/hooks/useTreenomeState.js
+++ b/taxonium_web_client/src/hooks/useTreenomeState.js
@@ -73,8 +73,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
   }, [data.base_data, settings.treenomeEnabled]);
 
   const handleResize = useCallback(() => {
-    console.log("calling handleResize");
-    console.log(deckRef.current, settings.treenomeEnabled);
     if (
       !deckRef.current ||
       !deckRef.current.deck ||
@@ -83,19 +81,14 @@ const useTreenomeState = (data, deckRef, view, settings) => {
     ) {
       return;
     }
-    console.log("here in handleResize");
     const tempViewState = { ...view.viewState };
-    console.log("tempViewState", tempViewState);
     view.setViewState(view.baseViewState);
-    console.log("baseViewState", view.baseViewState);
     const vp = {
       ...deckRef.current.deck.getViewports()[1],
     };
-    console.log("unprojecting:::resize");
     vp && setXbounds([vp.unproject([0, 0])[0], vp.unproject([vp.width, 0])[0]]);
 
     view.setViewState(tempViewState);
-    console.log("back to ", view.viewState);
   }, [deckRef, setXbounds, view, settings.treenomeEnabled]);
 
   useEffect(() => {
@@ -109,7 +102,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
   const [handled, setHandled] = useState(false);
   useEffect(() => {
     if (jbrowseLoaded && !handled) {
-      console.log("handle resize");
       window.setTimeout(() => {
         handleResize();
       }, 200);
@@ -124,7 +116,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
     ) {
       const jbrowse = document.getElementById("view-browser-axis");
       if (jbrowse) {
-        console.log("set jbrowse loaded");
         setJbrowseLoaded(jbrowse);
         mutationInstance.disconnect();
       }
@@ -150,8 +141,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
     };
 
     if (pxPerBp) {
-      console.log("thisone");
-
       setBpWidth(vp.unproject([pxPerBp, 0])[0] - vp.unproject([0, 0])[0]);
     }
   }, [deckRef, pxPerBp, settings.treenomeEnabled]);

--- a/taxonium_web_client/src/hooks/useTreenomeState.js
+++ b/taxonium_web_client/src/hooks/useTreenomeState.js
@@ -10,9 +10,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
   const [genomeSize, setGenomeSize] = useState(0);
   const [genome, setGenome] = useState(null);
 
-  const chromosomeName = useMemo(() => {
-    return settings.isCov2Tree ? "NC_045512v2" : "chromosome";
-  }, [settings.isCov2Tree]);
 
   useEffect(() => {
     if (
@@ -172,7 +169,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
       handleResize,
       genome,
       genomeSize,
-      chromosomeName,
       baseYBounds,
     };
   }, [
@@ -186,7 +182,6 @@ const useTreenomeState = (data, deckRef, view, settings) => {
     handleResize,
     genome,
     genomeSize,
-    chromosomeName,
     baseYBounds,
   ]);
 

--- a/taxonium_web_client/yarn.lock
+++ b/taxonium_web_client/yarn.lock
@@ -2409,10 +2409,10 @@
   resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jbrowse/core@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/core/-/core-2.1.2.tgz#b08d9d6914d67095b997de6a26ead6c3ecbd495d"
-  integrity sha512-7pml5nFrYnjWdSrL7q8/TgNZ8f7BJeDtJWuzloarasgoC/kAqY4uVM/I4+OOvRjiuTSFlaPjhPwaBqdCk1jdSA==
+"@jbrowse/core@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/core/-/core-2.1.4.tgz#ac55555c927d2e4c7ab33c14ca577f9af5bd4c8d"
+  integrity sha512-R+T/0UbRLePE+KsSnc3rLDwRMjCk8Ae3giPF29j2a/Nte8qhq222lfCcLOb+vTYJDeVVaEmUkkge3lnnpRkDyg==
   dependencies:
     "@babel/runtime" "^7.17.9"
     "@mui/icons-material" "^5.0.1"
@@ -2443,10 +2443,10 @@
     shortid "^2.2.13"
     svg-path-generator "^1.1.0"
 
-"@jbrowse/plugin-alignments@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-alignments/-/plugin-alignments-2.1.2.tgz#8af18cff4eef61b07e68561b5d9d6008b71a9ba2"
-  integrity sha512-s1oqYvmGgaASp2gJv2KeGUSIUGqPNUzgsX5LgPEMNFB82P8vvEjPzjTT3F3bmsVgUvgkL4HBlfUqAl3kV549nw==
+"@jbrowse/plugin-alignments@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-alignments/-/plugin-alignments-2.1.4.tgz#400ce52284095ce03baff432bcf7e63909b22ae6"
+  integrity sha512-Ql/rkbBKpd/5nlH0o7JGzvWaG9hUYtCK5ZaGnnQr8d1pO9YKGR2NMXKz1QH85LwIGB5xzPSLPL5P63XELcusww==
   dependencies:
     "@gmod/bam" "^1.1.15"
     "@gmod/cram" "^1.6.4"
@@ -2456,10 +2456,10 @@
     fast-deep-equal "^3.1.3"
     generic-filehandle "^3.0.0"
 
-"@jbrowse/plugin-bed@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-bed/-/plugin-bed-2.1.2.tgz#74b1fe5e73044746da1504c8a430d7a5e3e23efb"
-  integrity sha512-OjrWz5QPH/kKTkfMlAsJ/+YTMRKkUZP+Y7MsIw41G67aNwa5fQgFFKcVUfBqkxbBzYWACtaMjfe4uvTGaT34gw==
+"@jbrowse/plugin-bed@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-bed/-/plugin-bed-2.1.4.tgz#c18fe6a378200423374a2791e510179675a99afd"
+  integrity sha512-BJWnLpUStW7IbUEyuQUmwkM71j2wi/rcsS3smMmqbTJ43soybZjMn5cVoe1FQFZwW36KVcq4lKL5wJtcXHQpcw==
   dependencies:
     "@flatten-js/interval-tree" "^1.0.15"
     "@gmod/bbi" "^2.0.2"
@@ -2467,32 +2467,20 @@
     "@gmod/bgzf-filehandle" "^1.4.3"
     "@gmod/tabix" "^1.5.2"
 
-"@jbrowse/plugin-circular-view@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-circular-view/-/plugin-circular-view-2.1.2.tgz#de78d62c15462cec3fe09dbeb728651858de729f"
-  integrity sha512-pIt2F5Gg7g4VeURMTTF6/rgMKH0YVrpvwBYD+xtW2p6Evuxa30n6EckUgVDogd4Psqn+jv70/ptfbq1uPeldEg==
+"@jbrowse/plugin-circular-view@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-circular-view/-/plugin-circular-view-2.1.4.tgz#64f0677f5aa2e1aeddc1a5aaf6d7896beb616f6b"
+  integrity sha512-Oj6rW0Kx/9qiAB/vgomOZJbwEY3CWgig8sKmcQ7ShgINkOl4Shsi4XwGTFMX2sLBBJLLer4QWP6CrslYJ+Ee4w==
   dependencies:
     "@mui/icons-material" "^5.0.1"
 
-"@jbrowse/plugin-config@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-config/-/plugin-config-2.1.2.tgz#fe116f4f0199871f424b77352dc614175f582b1f"
-  integrity sha512-88bGg0BoxyVYQNZz5otQlZkGzx4EnMiX5LA/zmYXuTpa5RxZbJZ8cDYB22gTIbR1GwF/nSNK4mnv2gxnUlmUfg==
+"@jbrowse/plugin-config@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-config/-/plugin-config-2.1.4.tgz#dcc3ccb5debcdc8c6a263c2a0aaee8b89f13bad1"
+  integrity sha512-lGbeGVTjk0Lr3vZliggUg4Lb6GDLuCyUA3lKNgGJRf5/nV0degoDIP+mqDmA58mUtvC3kvoicba47AJUurUUkg==
   dependencies:
     "@mui/icons-material" "^5.0.1"
     pluralize "^8.0.0"
-
-"@jbrowse/plugin-data-management@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-data-management/-/plugin-data-management-2.1.2.tgz#98267a7325980088fd3c09efdb1c827ab33d152f"
-  integrity sha512-7aKmANr7v39mUYVJkhOIEFIh/NGmpWhUmM4Ss7OM/p2m8Q+trQCwkhyXhJMe5ZuqN12+s1yCMVyWyBJc5iyN8w==
-  dependencies:
-    "@gmod/ucsc-hub" "^0.1.3"
-    "@mui/icons-material" "^5.0.1"
-    clsx "^1.1.0"
-    react-virtualized-auto-sizer "^1.0.2"
-    react-vtree "^3.0.0-beta.1"
-    react-window "^1.8.6"
 
 "@jbrowse/plugin-data-management@^2.1.4":
   version "2.1.4"
@@ -2506,20 +2494,20 @@
     react-vtree "^3.0.0-beta.1"
     react-window "^1.8.6"
 
-"@jbrowse/plugin-gff3@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-gff3/-/plugin-gff3-2.1.2.tgz#7ed37b3762736f2efd1057dda97bb4dae779e436"
-  integrity sha512-ovqoWtPnMsm5sdsSBdk8r+XdKMlU6z7rOTBK4G/4M8Ep4tmfmIO+OCoWsPR7WDY+w56Fa+x2u10nd/Y7ORl2Ew==
+"@jbrowse/plugin-gff3@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-gff3/-/plugin-gff3-2.1.4.tgz#51d45beede63d6cbc2d3018da8ec0088f69284b5"
+  integrity sha512-scl1+v8c9LUGem+RFz73INcGhPR8pPJk7QhtpaxqV1q/jjSdC6ivVqweSDqZaVhc29wqqTHv1gsQ4JM8mlZmXA==
   dependencies:
     "@flatten-js/interval-tree" "^1.0.15"
     "@gmod/bgzf-filehandle" "^1.4.3"
     "@gmod/gff" "^1.2.0"
     "@gmod/tabix" "^1.5.2"
 
-"@jbrowse/plugin-legacy-jbrowse@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-legacy-jbrowse/-/plugin-legacy-jbrowse-2.1.2.tgz#7972adeec028f94dcc3eb60d93981b457de7e1c9"
-  integrity sha512-BnGnB4z7kTn0ArrCNLCXKkBEYleVEnJDdThjTtAvB1v0llfChTi48olZBfINQ+PftU6gt8D6g3XwbVONWfYTng==
+"@jbrowse/plugin-legacy-jbrowse@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-legacy-jbrowse/-/plugin-legacy-jbrowse-2.1.4.tgz#2ce574d65c4dad5adb33662adc9dc4c90846d87d"
+  integrity sha512-1bYRpcyGVB6ozQfDGBMFDBD+12roWYT16K4xffbLQLWyaf5mkTF4f3zNyTdYw/TJn/keHJ4l9Y2VySxEJexV2g==
   dependencies:
     "@gmod/nclist" "^0.2.1"
     buffer-crc32 "^0.2.13"
@@ -2527,10 +2515,10 @@
     get-value "^3.0.1"
     set-value "^4.0.1"
 
-"@jbrowse/plugin-linear-genome-view@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-linear-genome-view/-/plugin-linear-genome-view-2.1.2.tgz#4382f1ab311ebcaeaaf8635d9dbd275c0a4070b7"
-  integrity sha512-syD58izYlNk5vhtkFY5y1VNuEz9BddbuCKYi3wJeO3+lBIvbjAnn6TVDT3vt5YDJyAEvNC2O4AngTgFbcCT3jg==
+"@jbrowse/plugin-linear-genome-view@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-linear-genome-view/-/plugin-linear-genome-view-2.1.4.tgz#16da633ee8b270a43ee5ab887502901a44b2a0e8"
+  integrity sha512-VBoTxfjPnXEq/vcBfHkmZhRBBu03dXwCf47rxzhhbW1uqR9uOm7v/Vwma97fb/UafmEtWmWpkqYIWOc/dc39Yw==
   dependencies:
     "@mui/icons-material" "^5.0.1"
     "@popperjs/core" "^2.11.0"
@@ -2542,31 +2530,31 @@
     normalize-wheel "^1.0.1"
     react-popper "^2.0.0"
 
-"@jbrowse/plugin-sequence@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-sequence/-/plugin-sequence-2.1.2.tgz#d52ef33e4fcaf7c3de6f101928aebd6b4358ba72"
-  integrity sha512-kC5+YKBK24+3sUm/MkrUc/iJW9vywqrdrQr+VF+YiG1PQsUEjLg4KGPN6m809QXjQvV0PxR+BnoGww0J5cndkQ==
+"@jbrowse/plugin-sequence@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-sequence/-/plugin-sequence-2.1.4.tgz#a381fef58499634bdcccad086733d1450c755e1a"
+  integrity sha512-MikWkHS5VuNqWyzRdRX5DBwsbqIekbKw534NFd9LSpSdIZkvTUF/YPqlGqI93XiE2LgBL0Nma4xtgsZuBCSa6Q==
   dependencies:
     "@gmod/indexedfasta" "^2.0.2"
     "@gmod/twobit" "^1.1.12"
     abortable-promise-cache "^1.5.0"
 
-"@jbrowse/plugin-svg@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-svg/-/plugin-svg-2.1.2.tgz#2717badf425efa3141c7fd6f214fb232adb75f72"
-  integrity sha512-lUpNv9cxzCgYTmpDeCT6s+aNoUe/iQyUrB34wXkvzxe6yZ8gT86I22R0QabxwzvtzctlrdMfrAczeRK6jJif3Q==
+"@jbrowse/plugin-svg@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-svg/-/plugin-svg-2.1.4.tgz#b19fb70a665f033291f67c82c19f6948d259ca4f"
+  integrity sha512-adXUIeEq5UtaafrWn0lo8aNyDOBubyjeXvPk5eeSUKHpZ+tx154a6PiVdO4zFQCvMvgOe3nSDac1Hjf9cIWAbw==
 
-"@jbrowse/plugin-trix@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-trix/-/plugin-trix-2.1.2.tgz#c20758d0cd0334e21191e81b95856c9062dce8d3"
-  integrity sha512-WdaejS/ved0Gy3Ipe/7ou0VkvmQXRkT4gwAMZAgdO/QASnuN1Oxqyv/EQYT9E8vZOEczPubNF81YpEoY5myvNQ==
+"@jbrowse/plugin-trix@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-trix/-/plugin-trix-2.1.4.tgz#54320e9e830089371f8d45747ffdf354cdabf069"
+  integrity sha512-E4y4MNEAu2bW2ZLNWELP5yaH+GM6Tbg/vWHbhZ90l4BHRrED8slV3Pt5ewZ4gu15L5fo/3gsU5Iq1/x8sfy4Mw==
   dependencies:
     "@gmod/trix" "^2.0.4"
 
-"@jbrowse/plugin-variants@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-variants/-/plugin-variants-2.1.2.tgz#a23c2a640008f17bd3a82374f192472f4f2c68cd"
-  integrity sha512-fhzuUrdASpGHTNfhrUK2uNAK+UNVHtSHDU3uMfvHYfQWBaX5PHw6HggLIffEvAyMXfUaI/w+gvT1Cv7OWSi4fQ==
+"@jbrowse/plugin-variants@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-variants/-/plugin-variants-2.1.4.tgz#9a912f4202171a2a4c416b6980d218827eb04da4"
+  integrity sha512-zim9GurYwlImUDIT+RA9VQsrgjYwQriZuJS8kMfTFbgDOAape5/Pnn3qAhR4c98a35SVx6pYMWLCah46px9RtQ==
   dependencies:
     "@flatten-js/interval-tree" "^1.0.15"
     "@gmod/bgzf-filehandle" "^1.4.3"
@@ -2576,10 +2564,10 @@
     "@mui/x-data-grid" "^5.0.1"
     generic-filehandle "^3.0.0"
 
-"@jbrowse/plugin-wiggle@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/plugin-wiggle/-/plugin-wiggle-2.1.2.tgz#4a1c86c69760f912810ea82d09d794f7ae09e421"
-  integrity sha512-ng0fazqUj01qmafbin413f8aWIFHT0biY6Ui7anbV+Poop46Pl3xnhlFb8wNs/PcQ2uRPfEqhCwI/DGMZ+oBPw==
+"@jbrowse/plugin-wiggle@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-wiggle/-/plugin-wiggle-2.1.4.tgz#2ccfa3aba3088fcd319a222ab57b5577074aa4c9"
+  integrity sha512-EZlQRR3utd9lpq88TSJI8YCbB9OCPpDKunv4WNB0hmOaDtOK4wamBJNRcPp/OLrBqR/+T1D4qhTV9IyUxl5itQ==
   dependencies:
     "@gmod/bbi" "^2.0.2"
     "@mui/icons-material" "^5.0.2"
@@ -2594,29 +2582,29 @@
     react-draggable "^4.4.5"
     react-popper "^2.0.0"
 
-"@jbrowse/react-linear-genome-view@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@jbrowse/react-linear-genome-view/-/react-linear-genome-view-2.1.2.tgz#4d80429ac2858dec1031943ee91f586ba82ada38"
-  integrity sha512-X5neVKCNcWjtXkJ4EV4uB4pJ2QRVmuApEGuQRgGqhvCod4l94pV6EVsFwcOtjIkIv4X0ttrIGwm2U9Q132YuMQ==
+"@jbrowse/react-linear-genome-view@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/react-linear-genome-view/-/react-linear-genome-view-2.1.4.tgz#8851e98bf8910fc6ea4ab718583db5f97dd66484"
+  integrity sha512-HAj9d7X7ntCiG4FTxSVj1zgExPLmhmWhtrS5HQcAPrw1kx9UvGOdlgOW5CeMkVligO5J44UHr0oWtyJ7VD54pg==
   dependencies:
     "@babel/runtime" "^7.17.9"
     "@emotion/cache" "^11.7.1"
     "@emotion/react" "^11.9.0"
     "@emotion/styled" "^11.8.1"
-    "@jbrowse/core" "^2.1.2"
-    "@jbrowse/plugin-alignments" "^2.1.2"
-    "@jbrowse/plugin-bed" "^2.1.2"
-    "@jbrowse/plugin-circular-view" "^2.1.2"
-    "@jbrowse/plugin-config" "^2.1.2"
-    "@jbrowse/plugin-data-management" "^2.1.2"
-    "@jbrowse/plugin-gff3" "^2.1.2"
-    "@jbrowse/plugin-legacy-jbrowse" "^2.1.2"
-    "@jbrowse/plugin-linear-genome-view" "^2.1.2"
-    "@jbrowse/plugin-sequence" "^2.1.2"
-    "@jbrowse/plugin-svg" "^2.1.2"
-    "@jbrowse/plugin-trix" "^2.1.2"
-    "@jbrowse/plugin-variants" "^2.1.2"
-    "@jbrowse/plugin-wiggle" "^2.1.2"
+    "@jbrowse/core" "^2.1.4"
+    "@jbrowse/plugin-alignments" "^2.1.4"
+    "@jbrowse/plugin-bed" "^2.1.4"
+    "@jbrowse/plugin-circular-view" "^2.1.4"
+    "@jbrowse/plugin-config" "^2.1.4"
+    "@jbrowse/plugin-data-management" "^2.1.4"
+    "@jbrowse/plugin-gff3" "^2.1.4"
+    "@jbrowse/plugin-legacy-jbrowse" "^2.1.4"
+    "@jbrowse/plugin-linear-genome-view" "^2.1.4"
+    "@jbrowse/plugin-sequence" "^2.1.4"
+    "@jbrowse/plugin-svg" "^2.1.4"
+    "@jbrowse/plugin-trix" "^2.1.4"
+    "@jbrowse/plugin-variants" "^2.1.4"
+    "@jbrowse/plugin-wiggle" "^2.1.4"
     "@mui/icons-material" "^5.0.0"
     "@mui/material" "^5.0.0"
     mobx "^6.6.0"

--- a/taxonium_web_client/yarn.lock
+++ b/taxonium_web_client/yarn.lock
@@ -2494,6 +2494,18 @@
     react-vtree "^3.0.0-beta.1"
     react-window "^1.8.6"
 
+"@jbrowse/plugin-data-management@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@jbrowse/plugin-data-management/-/plugin-data-management-2.1.4.tgz#6024b369bfe0b109accd7e68b41f042855ed460b"
+  integrity sha512-1B7L8zAzivtRmxeYYSip8uvJX6AXmqWFIMqA6Oizm0WOZa8/8I7VdijQvxhRCplU+iJOka9YGvDvOoaYNvTQMw==
+  dependencies:
+    "@gmod/ucsc-hub" "^0.1.3"
+    "@mui/icons-material" "^5.0.1"
+    clsx "^1.1.0"
+    react-virtualized-auto-sizer "^1.0.2"
+    react-vtree "^3.0.0-beta.1"
+    react-window "^1.8.6"
+
 "@jbrowse/plugin-gff3@^2.1.2":
   version "2.1.2"
   resolved "https://registry.npmjs.org/@jbrowse/plugin-gff3/-/plugin-gff3-2.1.2.tgz#7ed37b3762736f2efd1057dda97bb4dae779e436"


### PR DESCRIPTION
This is a draft of incorporating custom annotation tracks. It adds the `AddTrackWidget` from the JBrowse data management plugin, which lets users provide annotations in the form of a file or URL.

It's not quite plug-and-play, because (I think?) the plugin might not have been written with the React JBrowse component we are using in mind (`react-linear-genome-view`). Specifically, the plugin tries to call the function `addTrackConf`, but the `state` object does not contain that function. So I manually add that function the state object at line 271 in `JBrowsePanel.jsx`.

Also, to deal with assembly names for custom trees, and different names for the same SARS-CoV-2 assembly, I added a settings modal to the Treenome side to manually set the assembly name.

Most annotation files seem to work, but (some? all?) VCF files cause the window to crash (with an error about "invalid SceneGraph arguments"). I think this is a bug on the JBrowse side, but I'm not positive.

I'll keep trying to trace down what is going on with the VCF files, but I think this could be merged soon-ish if we disallow VCF and if you agree with the changes @theosanderson !