### PR TITLE
serve custom cov-2 features for cdph trees

### DIFF
--- a/taxonium_web_client/src/hooks/useSettings.js
+++ b/taxonium_web_client/src/hooks/useSettings.js
@@ -86,7 +86,10 @@ export const useSettings = ({ query, updateQuery }) => {
   const [chromosomeName, setChromosomeName] = useState("chromosome");
   const [isCov2Tree, setIsCov2Tree] = useState(false);
   useEffect(() => {
-    if (window.location.href.includes("cov2tree.org") || window.location.href.includes("big-tree.ucsc.edu")) {
+    if (
+      window.location.href.includes("cov2tree.org") ||
+      window.location.href.includes("big-tree.ucsc.edu")
+    ) {
       setIsCov2Tree(true);
       setChromosomeName("NC_045512v2");
     }

--- a/taxonium_web_client/src/hooks/useSettings.js
+++ b/taxonium_web_client/src/hooks/useSettings.js
@@ -86,7 +86,7 @@ export const useSettings = ({ query, updateQuery }) => {
   const [chromosomeName, setChromosomeName] = useState("chromosome");
   const [isCov2Tree, setIsCov2Tree] = useState(false);
   useEffect(() => {
-    if (window.location.href.includes("cov2tree.org")) {
+    if (window.location.href.includes("cov2tree.org") || window.location.href.includes("big-tree.ucsc.edu")) {
       setIsCov2Tree(true);
       setChromosomeName("NC_045512v2");
     }


### PR DESCRIPTION
small addition to the URL recognition logic that will allow the CDPH custom backend to load the UCSC annotations (and other cov2tree-specific features) in Treenome Browser.