### PR TITLE
Fix calculation of past mutations

### DIFF
--- a/taxoniumtools/src/taxoniumtools/ushertools.py
+++ b/taxoniumtools/src/taxoniumtools/ushertools.py
@@ -115,7 +115,7 @@ def get_mutations(past_nuc_muts_dict,
 
         initial_codon = [seq[gene_codon.positions[x]] for x in range(3)]
 
-        relevant_past_muts = [(x, past_nuc_muts_dict[x])
+        relevant_past_muts = [(gene_codon.positions[x], past_nuc_muts_dict[x])
                               for x in gene_codon.positions
                               if x in past_nuc_muts_dict]
         flipped_dict = {


### PR DESCRIPTION
[v2.0.108](https://github.com/theosanderson/taxonium/releases/tag/v2.0.108) introduced a significant bug in adding support for compound features. This likely means that mutations are misannotated due to not considering previous mutations correctly. It also caused crashes in some circumstances (https://github.com/theosanderson/taxonium/issues/499#issuecomment-1656108278). 

@AngieHinrichs kindly figured out exactly what the bug was here, and what the fix is! It seems to work in the sense that I don't get a crash for the dengue dataset anymore. I have not tested further but am rolling this out because we know the current implementation is wrong. Apologies for the problems and thanks again to Angie for the fix.