### PR TITLE
Fix genotype colour issue

### DIFF
--- a/taxonium_component/src/components/SearchPanel.jsx
+++ b/taxonium_component/src/components/SearchPanel.jsx
@@ -342,9 +342,7 @@ function SearchPanel({
         {colorBy.colorByField === "genotype" && (
       
           <div className="space-x-2">
-            <div className="text-xs">
-        If you are using custom JSONLs there is currently a bug with genotype colouring, please use <a className="text-blue-800" href="https://cov2tree-9k82lpuou-theosanderson.vercel.app/">this old version</a>.
-        </div>
+            
             <label className="space-x-2">
               <span>Gene</span>
               <Select

--- a/taxonium_component/src/hooks/useLayers.jsx
+++ b/taxonium_component/src/hooks/useLayers.jsx
@@ -118,6 +118,7 @@ const useLayers = ({
     }
   }, [data.base_data, getX]);
 
+  
   const detailed_scatter_data = useMemo(() => {
     return detailed_data.nodes.filter(
       (node) =>
@@ -157,10 +158,11 @@ const useLayers = ({
   const scatter_layer_common_props = {
     getPosition: (d) => [getX(d), d.y],
     getFillColor: (d) => toRGB(getNodeColorField(d, detailed_data)),
-
+    getRadius: 3,
     // radius in pixels
-    getRadius: (d) =>
-      getNodeColorField(d, detailed_data) === hoveredKey ? 4 : 3,
+    // we had to get rid of the below because it was messing up the genotype colours
+   // getRadius: (d) =>
+    //  getNodeColorField(d, detailed_data) === hoveredKey ? 4 : 3,
     getLineColor: [100, 100, 100],
     opacity: 0.6,
     stroked: data.data.nodes && data.data.nodes.length < 3000,

--- a/taxonium_component/src/stories/Taxonium.stories.jsx
+++ b/taxonium_component/src/stories/Taxonium.stories.jsx
@@ -136,7 +136,7 @@ export const JSONLgenetic = {
   args: {
     sourceData: {
       status: "url_supplied",
-      filename: "https://cov2tree.nyc3.cdn.digitaloceanspaces.com/tfci-taxonium2.jsonl",
+      filename: "https://cov2tree.nyc3.cdn.digitaloceanspaces.com/tfci-taxonium.jsonl.gz",
       filetype: "jsonl",
     },
   },


### PR DESCRIPTION
Adding the "hover over key to highlight nodes" feature somehow introduced an issue reported in this comment: https://github.com/theosanderson/taxonium/issues/523#issuecomment-1719041810

Some sort of race condition where the cache gets built before it is ready. For now we remove this.