### PR TITLE
doc: recommend explicit /usr/bin/xattr to prevent error

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -14,7 +14,7 @@ On MacOS you will need to "unquarantine" the app, because the code has not been 
 Please use the terminal command below to achieve this:
 
 ```
-sudo xattr -r -d com.apple.quarantine "/Applications/Taxonium.app"
+sudo /usr/bin/xattr -r -d com.apple.quarantine "/Applications/Taxonium.app"
 ```
 
 (if Taxonium is stored at that location)


### PR DESCRIPTION
If people have a Python-installed xattr on path before /usr/bin they'll get the error: `option -r not recognized`

Safer to use explicit system-supplied binary: https://apple.stackexchange.com/questions/472652/when-invoking-xattr-with-r-flag-get-error-option-r-not-recognized