### PR TITLE
Add a new option --chronumental_add_inferred_date

### DIFF
--- a/taxoniumtools/src/taxoniumtools/usher_to_taxonium.py
+++ b/taxoniumtools/src/taxoniumtools/usher_to_taxonium.py
@@ -28,6 +28,7 @@ def do_processing(input_file,
                   chronumental_date_output=None,
                   chronumental_tree_output=None,
                   chronumental_reference_node=None,
+                  chronumental_add_inferred_date=None,
                   config_file=None,
                   title=None,
                   overlay_html=None,
@@ -82,7 +83,10 @@ def do_processing(input_file,
             metadata_file=metadata_file,
             chronumental_steps=chronumental_steps,
             chronumental_date_output=chronumental_date_output,
-            chronumental_tree_output=chronumental_tree_output)
+            chronumental_tree_output=chronumental_tree_output,
+            chronumental_add_inferred_date=chronumental_add_inferred_date,
+            metadata_dict=metadata_dict,
+            metadata_cols=metadata_cols)
 
     print("Ladderizing tree..")
     mat.tree.ladderize(ascending=False)
@@ -237,6 +241,12 @@ def get_parser():
         "A reference node to be used for Chronumental. This should be earlier in the outbreak and have a good defined date. If not set the oldest sample will be automatically picked by Chronumental.",
         default=None)
     parser.add_argument(
+        "--chronumental_add_inferred_date",
+        type=str,
+        help=
+        "A new metadata-column-like name to be added for display with the value of Chronumental's inferred date for each sample.",
+        default=None)
+    parser.add_argument(
         '-j',
         "--config_json",
         type=str,
@@ -304,26 +314,28 @@ def main():
     parser = get_parser()
 
     args = parser.parse_args()
-    do_processing(args.input,
-                  args.output,
-                  metadata_file=args.metadata,
-                  genbank_file=args.genbank,
-                  chronumental_enabled=args.chronumental,
-                  chronumental_steps=args.chronumental_steps,
-                  columns=args.columns,
-                  chronumental_date_output=args.chronumental_date_output,
-                  chronumental_tree_output=args.chronumental_tree_output,
-                  chronumental_reference_node=args.chronumental_reference_node,
-                  config_file=args.config_json,
-                  title=args.title,
-                  overlay_html=args.overlay_html,
-                  remove_after_pipe=args.remove_after_pipe,
-                  clade_types=args.clade_types,
-                  name_internal_nodes=args.name_internal_nodes,
-                  shear=args.shear,
-                  shear_threshold=args.shear_threshold,
-                  only_variable_sites=args.only_variable_sites,
-                  key_column=args.key_column)
+    do_processing(
+        args.input,
+        args.output,
+        metadata_file=args.metadata,
+        genbank_file=args.genbank,
+        chronumental_enabled=args.chronumental,
+        chronumental_steps=args.chronumental_steps,
+        columns=args.columns,
+        chronumental_date_output=args.chronumental_date_output,
+        chronumental_tree_output=args.chronumental_tree_output,
+        chronumental_reference_node=args.chronumental_reference_node,
+        chronumental_add_inferred_date=args.chronumental_add_inferred_date,
+        config_file=args.config_json,
+        title=args.title,
+        overlay_html=args.overlay_html,
+        remove_after_pipe=args.remove_after_pipe,
+        clade_types=args.clade_types,
+        name_internal_nodes=args.name_internal_nodes,
+        shear=args.shear,
+        shear_threshold=args.shear_threshold,
+        only_variable_sites=args.only_variable_sites,
+        key_column=args.key_column)
 
 
 if __name__ == "__main__":

--- a/taxoniumtools/src/taxoniumtools/utils.py
+++ b/taxoniumtools/src/taxoniumtools/utils.py
@@ -109,7 +109,7 @@ def do_chronumental(mat, chronumental_reference_node, metadata_file,
                 if not os.path.exists(date_output_filename):
                     raise FileNotFoundError(
                         errno.ENOENT,
-                        f"Can't find default date output file in the expected lococation (try specifying a file name with --chronumental_date_output)",
+                        f"Can't find default date output file in the expected location (try specifying a file name with --chronumental_date_output)",
                         date_output_filename)
             metadata_cols.append(chronumental_add_inferred_date)
             inferred_dates = pd.read_csv(


### PR DESCRIPTION
This adds the new option `--chronumental_add_inferred_date <column_name>` that I suggested in #607.  Feel free to bounce it back if there is anything big or small that you'd like me to change / rename / reword / etc.

An example usage is
```
usher_to_taxonium -i my_tree.pb -m my_tree.metadata.tsv -o my_tree.jsonl.gz \
    --chronumental --chronumental_steps 300 \
    --chronumental_add_inferred_date chronumental_date
```
After running chronumental, it reads the date output file(*) and adds a new metadata 'column' (in this example, `chronumental_date`) whose value for each node is the date inferred by chronumental for that node.  When viewing the resulting `my_tree.jsonl.gz` in taxonium, the inferred date is displayed for each node when hovering over or clicking on the node, appearing as an extra metadata item.  When the node is clicked on, the label for the inferred date is "Chronumental date" in this example (derived the usual way from `chronumental_date`).

(*) The date output file is either the filename specified with `--chronumental_date_output` if given, or the default name which currently is derived from the metadata file name (`chronumental_dates_`_metadata_file_`.tsv`).  If `--chronumental_date_output` is not given and the expected metadata-derived date output file does not exist, then it quits with a suggestion to add `--chronumental_date_output`.

I have tested it with and without `--chronumental_date_output` and with a relative and absolute path for the metadata file from which the default date output file name is derived, and it seems to work.

Thanks as always for taxonium, don't know what I'd do without it!  🙂 