### PR TITLE
New server side endpoint for getting (all) mutations, which provides data in chunks

### DIFF
--- a/taxonium_component/src/hooks/useServerBackend.jsx
+++ b/taxonium_component/src/hooks/useServerBackend.jsx
@@ -121,20 +121,66 @@ function useServerBackend(backend_url, sid, url_on_fail) {
     },
     [backend_url, sid]
   );
-
   const getConfig = useCallback(
     (setResult) => {
-      let url = backend_url + "/config/?sid=" + sid;
-      axios.get(url).then(function (response) {
-        console.log("got config", response.data);
-        if (response.data.error) {
-          window.alert(
-            response.data.error + (url_on_fail ? "\nRedirecting you." : "")
-          );
-          window.location.href = url_on_fail;
-        }
-        setResult(response.data);
-      });
+      const url = `${backend_url}/config/?sid=${sid}`;
+      
+      // Fetch initial config
+      axios.get(url)
+        .then(response => {
+          console.log("got config", response.data);
+          if (response.data.error) {
+            window.alert(
+              response.data.error + (url_on_fail ? "\nRedirecting you." : "")
+            );
+            window.location.href = url_on_fail;
+            return;
+          }
+          
+          const config = response.data;
+          config.mutations = config.mutations ? config.mutations : [];
+       
+          // Stream mutations
+          const mutationsUrl = `${backend_url}/mutations/?sid=${sid}`;
+          const eventSource = new EventSource(mutationsUrl);
+  
+          eventSource.onmessage = (event) => {
+            if (event.data === "END") {
+              console.log("Finished receiving mutations");
+              eventSource.close();
+              setResult(config);
+              return;
+            }
+  
+            try {
+              const mutationsChunk = JSON.parse(event.data);
+              if (Array.isArray(mutationsChunk)) {
+                config.mutations.push(...mutationsChunk);
+                setResult({ ...config });
+                console.log(`Received chunk of ${mutationsChunk.length} mutations`);
+              } else {
+                console.error("Received non-array chunk:", mutationsChunk);
+              }
+            } catch (error) {
+              console.error("Error parsing mutations chunk:", error);
+            }
+          };
+  
+          eventSource.onerror = (error) => {
+            console.error("EventSource failed:", error);
+            eventSource.close();
+          };
+  
+          // Set initial config
+          setResult(config);
+        })
+        .catch(error => {
+          console.error("Error fetching config:", error);
+          if (url_on_fail) {
+            window.alert("Failed to fetch config. Redirecting you.");
+            window.location.href = url_on_fail;
+          }
+        });
     },
     [backend_url, sid, url_on_fail]
   );


### PR DESCRIPTION
The backend provides a list of all the mutations present in the tree initially. Otherwise, mutations are referred to by numeric ID. In #613 Angie Hinrichs describes a problem whereby for trees for very large organisms, when encoded in JSON the list of mutations is more than 1 GB which is more than the JS string limit. This imposes a number of problems.

This PR mitigates some of these problems. Previously the mutations were returned as part of the `/config` endpoint. Now we create a new endpoint that provides chunked data with an event stream so mutations can be processed in batches rather than needing to handle a 1 GB string.

There is a separate issue in terms of actually reading in the mutations, which are in the first line of the JSONL file. That is being explored in #614.