### PR TITLE
Reduce mutation chunk size

### DIFF
--- a/taxonium_backend/server.js
+++ b/taxonium_backend/server.js
@@ -231,7 +231,7 @@ app.get("/mutations/", function (req, res) {
   }
 
   // Send mutations in chunks of 100000
-  const chunkSize = 100000;
+  const chunkSize = 10000;
   let index = 0;
 
   function sendNextChunk() {


### PR DESCRIPTION
In Safari we are hitting:
<img width="586" alt="image" src="https://github.com/user-attachments/assets/e22569ed-cd64-4bff-b739-9186d0f35781">
