### PR TITLE
On taxonium_website when the little icons display next to each tree they should be part of the link to the tree

### DIFF
--- a/taxonium_website/src/App.jsx
+++ b/taxonium_website/src/App.jsx
@@ -196,13 +196,11 @@ function App() {
                     {pathConfig &&
                       pathConfig.maintainerMessage &&
                       pathConfig.icon && (
-                     
-                          <img
-                            src={pathConfig.icon}
-                            className="w-6 h-6  rounded border-gray-400 border inline-block"
-                            title={pathConfig.maintainerMessage}
-                          />
-                       
+                        <img
+                          src={pathConfig.icon}
+                          className="w-6 h-6  rounded border-gray-400 border inline-block"
+                          title={pathConfig.maintainerMessage}
+                        />
                       )}
                     <span
                       className={`font-medium ${

--- a/taxonium_website/src/App.jsx
+++ b/taxonium_website/src/App.jsx
@@ -196,11 +196,13 @@ function App() {
                     {pathConfig &&
                       pathConfig.maintainerMessage &&
                       pathConfig.icon && (
-                        <img
-                          src={pathConfig.icon}
-                          className="w-6 h-6  rounded border-gray-400 border inline-block"
-                          title={pathConfig.maintainerMessage}
-                        />
+                     
+                          <img
+                            src={pathConfig.icon}
+                            className="w-6 h-6  rounded border-gray-400 border inline-block"
+                            title={pathConfig.maintainerMessage}
+                          />
+                       
                       )}
                     <span
                       className={`font-medium ${
@@ -295,16 +297,16 @@ function App() {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {showCase.map((item, i) => (
                     <div key={i} className="border border-gray-300 rounded p-3">
-                      <img
-                        src={item.icon}
-                        className="w-6 h-6 rounded border-gray-500 mb-2 inline-block mr-2"
-                        title={item.maintainerMessage}
-                      />
                       <a
                         href={item.url}
                         className="text-gray-800 hover:underline"
                         target="_top"
                       >
+                        <img
+                          src={item.icon}
+                          className="w-6 h-6 rounded border-gray-500 mb-2 inline-block mr-2"
+                          title={item.maintainerMessage}
+                        />
                         {item.title}
                       </a>
                       <p className="text-gray-600 text-sm">{item.desc}</p>


### PR DESCRIPTION
Wrap the little icons next to each tree in the same anchor tags as the tree titles to make them part of the link to the tree.

* In `taxonium_website/src/App.jsx`, wrap the `img` tags displaying the icons in the same anchor tags as the tree titles.
* Ensure the icons are clickable and lead to the respective tree pages.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theosanderson/taxonium/pull/640?shareId=8aa8e133-9bfb-436b-8333-0ab07f7130cf).