### PR TITLE
Add M. tuberculosis SRA UShER tree

### DIFF
--- a/taxonium_website/src/App.jsx
+++ b/taxonium_website/src/App.jsx
@@ -17,6 +17,7 @@ const SHOWCASE_PATHS = [
   "sars-cov-2/public",
   "taxonomy/visual",
   "taxonomy/full",
+  "tuberculosis/SRA",
   "mpox/clade-I",
   "mpox/clade-IIb",
   "flu/H5N1-Outbreak",

--- a/taxonium_website/src/trees.json
+++ b/taxonium_website/src/trees.json
@@ -38,7 +38,7 @@
   "tuberculosis/SRA": {
     "protoUrl": "https://hgdownload.gi.ucsc.edu/hubs/GCF/000/195/955/GCF_000195955.2/UShER_Mtb_SRA/mtb.20240912.mask10.jsonl.gz",
     "title": "Tuberculosis SRA",
-    "description": "M. tuberculosis genomes assembled from data desposited in SRA",
+    "description": "M. tuberculosis genomes assembled from data deposited in SRA",
     "icon": "/assets/usher.png",
     "maintainerMessage": "Maintained by the UShER team",
     "maintainerUrl": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace"

--- a/taxonium_website/src/trees.json
+++ b/taxonium_website/src/trees.json
@@ -36,7 +36,7 @@
     "maintainerUrl": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace"
   },
   "tuberculosis/SRA": {
-    "protoUrl": "https://hgdownload.gi.ucsc.edu/hubs/GCF/000/195/955/GCF_000195955.2/UShER_Mtb_SRA/mtb.20240912.mask10.jsonl.gz",
+    "backend": "https://mtb.api.taxonium.org",
     "title": "Tuberculosis SRA",
     "description": "M. tuberculosis genomes assembled from data deposited in SRA",
     "icon": "/assets/usher.png",

--- a/taxonium_website/src/trees.json
+++ b/taxonium_website/src/trees.json
@@ -24,7 +24,7 @@
     "legacyHostnames": ["mpx.taxonium.org"],
     "icon": "/assets/usher.png",
     "maintainerMessage": "Maintained by the UShER team",
-    "maintainerUrl": null
+    "maintainerUrl": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace"
   },
   "mpox/clade-IIb": {
     "protoUrl": "https://hgdownload.gi.ucsc.edu/hubs/GCF/014/621/545/GCF_014621545.1/UShER_hMPXV/mpxv.latest.masked.taxonium.jsonl.gz",
@@ -33,7 +33,15 @@
     "legacyHostnames": ["mpx.taxonium.org"],
     "icon": "/assets/usher.png",
     "maintainerMessage": "Maintained by the UShER team",
-    "maintainerUrl": null
+    "maintainerUrl": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace"
+  },
+  "tuberculosis/SRA": {
+    "protoUrl": "https://hgdownload.gi.ucsc.edu/hubs/GCF/000/195/955/GCF_000195955.2/UShER_Mtb_SRA/mtb.20240912.mask10.jsonl.gz",
+    "title": "Tuberculosis SRA",
+    "description": "M. tuberculosis genomes assembled from data desposited in SRA",
+    "icon": "/assets/usher.png",
+    "maintainerMessage": "Maintained by the UShER team",
+    "maintainerUrl": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace"
   },
   "taxonomy/full": {
     "treeUrl": "https://cov2tree.nyc3.digitaloceanspaces.com/ncbi/tree.nwk.gz",

--- a/taxonium_website/src/trees.json
+++ b/taxonium_website/src/trees.json
@@ -37,7 +37,7 @@
   },
   "tuberculosis/SRA": {
     "backend": "https://mtb.api.taxonium.org",
-    "title": "Tuberculosis SRA",
+    "title": "M. tuberculosis",
     "description": "M. tuberculosis genomes assembled from data deposited in SRA",
     "icon": "/assets/usher.png",
     "maintainerMessage": "Maintained by the UShER team",


### PR DESCRIPTION
This adds UCSC's M. tuberculosis SRA-only UShER tree to trees.json, as well as filling in the maintainerUrl for mpxv UShER trees to match other UShER trees.  Thanks!