### PR TITLE
Add H5N1 D1.1 outbreak UShER tree

### DIFF
--- a/taxonium_website/src/App.jsx
+++ b/taxonium_website/src/App.jsx
@@ -21,6 +21,7 @@ const SHOWCASE_PATHS = [
   "mpox/clade-I",
   "mpox/clade-IIb",
   "flu/H5N1-Outbreak",
+  "flu/H5N1-Outbreak-D1-1",
 ];
 
 function checkLegacyHostname() {

--- a/taxonium_website/src/trees.json
+++ b/taxonium_website/src/trees.json
@@ -66,8 +66,16 @@
   },
   "flu/H5N1-Outbreak": {
     "backend": "https://h5n1outbreak.api.taxonium.org",
-    "title": "H5N1 outbreak tree",
-    "description": "Outbreak tree of recent H5N1 outbreak",
+    "title": "H5N1 outbreak tree (B3.13)",
+    "description": "Outbreak tree of H5N1 B3.13 (cattle etc.) outbreak",
+    "icon": "/assets/usher.png",
+    "maintainerMessage": "Maintained by the UShER team",
+    "maintainerUrl": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace"
+  },
+  "flu/H5N1-Outbreak-D1-1": {
+    "protoUrl": "https://hgdownload.gi.ucsc.edu/hubs/GCF/000/864/105/GCF_000864105.1/UShER_h5n1_D1.1_2024/h5n1_D1.1_2024.latest.jsonl.gz",
+    "title": "H5N1 outbreak tree (D1.1)",
+    "description": "Outbreak tree of H5N1 D1.1 (poultry etc.) outbreak",
     "icon": "/assets/usher.png",
     "maintainerMessage": "Maintained by the UShER team",
     "maintainerUrl": "https://genome.ucsc.edu/cgi-bin/hgPhyloPlace"


### PR DESCRIPTION
This adds the very small (yet timely) UShER tree for the H5N1 genotype D1.1 outbreak in wild birds, domestic poultry and a few other species in the USA recently.  It also tweaks the name and description of the existing flu/H5N1-Outbreak tree to specify that its genotype is B3.13 and it's mostly in cattle (and a few other species).

I'm following the template of #645 except this is so small that I doubt it really needs a backend (?).  Thanks!