### PR TITLE
Simplify zoom implementation

### DIFF
--- a/taxonium_component/src/Deck.stories.tsx
+++ b/taxonium_component/src/Deck.stories.tsx
@@ -42,17 +42,14 @@ const createMockProps = (overrides = {}) => {
     },
     view: {
       viewState: {
-        zoom: 2,
+        zoom: [2, 2],
         target: [0, 0],
       },
       zoomReset: fn(),
       onViewStateChange: fn(),
       views: [{ id: "main" }, { id: "browser-axis" }],
       zoomIncrement: fn(),
-      zoomAxis: "X",
-      setZoomAxis: fn(),
-      xzoom: 1,
-      modelMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      zoomAxis: "Y",
       setMouseXY: fn(),
     },
     colorHook: {

--- a/taxonium_component/src/Deck.tsx
+++ b/taxonium_component/src/Deck.tsx
@@ -144,13 +144,7 @@ function Deck({
         });
       }
     },
-    [
-      selectedDetails,
-      mouseDownIsMinimap,
-      viewState,
-      onViewStateChange,
-      deckRef,
-    ]
+    [selectedDetails, mouseDownIsMinimap, viewState, onViewStateChange, deckRef]
   );
 
   const [hoverInfo, setHoverInfoRaw] = useState(null);

--- a/taxonium_component/src/Deck.tsx
+++ b/taxonium_component/src/Deck.tsx
@@ -65,10 +65,6 @@ function Deck({
     onViewStateChange,
     views,
     zoomIncrement,
-
-    zoomAxis,
-    setZoomAxis,
-    xzoom,
   } = view;
 
   // Treenome state
@@ -143,10 +139,7 @@ function Deck({
           specialMinimap: true,
           viewState: {
             ...viewState,
-            target: [
-              pickInfo.coordinate[0] / 2 ** (viewState.zoom - xzoom),
-              pickInfo.coordinate[1],
-            ],
+            target: [pickInfo.coordinate[0], pickInfo.coordinate[1]],
           },
         });
       }
@@ -156,7 +149,6 @@ function Deck({
       mouseDownIsMinimap,
       viewState,
       onViewStateChange,
-      xzoom,
       deckRef,
     ]
   );
@@ -188,9 +180,7 @@ function Deck({
     hoverInfo,
     colorBy,
     xType,
-    modelMatrix: view.modelMatrix,
     selectedDetails,
-    xzoom,
     settings,
     isCurrentlyOutsideBounds,
     config,
@@ -320,8 +310,6 @@ function Deck({
         deckSize={deckSize}
         zoomReset={zoomReset}
         zoomIncrement={zoomIncrement}
-        zoomAxis={zoomAxis}
-        setZoomAxis={setZoomAxis}
         snapshot={snapshot}
         loading={data.status === "loading"}
         requestOpenSettings={() => setDeckSettingsOpen(true)}

--- a/taxonium_component/src/components/DeckButtons.stories.tsx
+++ b/taxonium_component/src/components/DeckButtons.stories.tsx
@@ -14,8 +14,6 @@ export default {
 export const Default = {
   args: {
     loading: false,
-    setZoomAxis: fn(),
-    zoomAxis: "X",
     snapshot: fn(),
     zoomIncrement: fn(),
     requestOpenSettings: fn(),
@@ -33,9 +31,3 @@ export const Loading = {
   },
 };
 
-export const VerticalZoomAxis = {
-  args: {
-    ...Default.args,
-    zoomAxis: "Y",
-  },
-};

--- a/taxonium_component/src/components/DeckButtons.stories.tsx
+++ b/taxonium_component/src/components/DeckButtons.stories.tsx
@@ -30,4 +30,3 @@ export const Loading = {
     loading: true,
   },
 };
-

--- a/taxonium_component/src/components/DeckButtons.tsx
+++ b/taxonium_component/src/components/DeckButtons.tsx
@@ -16,8 +16,6 @@ import SnapshotButton from "./SnapshotButton";
 
 export const DeckButtons = ({
   loading,
-  setZoomAxis,
-  zoomAxis,
   snapshot,
   zoomIncrement,
   requestOpenSettings,
@@ -76,26 +74,6 @@ export const DeckButtons = ({
         >
           <TiCog className="mx-auto w-5 h-5 inline-block" />
         </TaxButton>
-        {/*<TaxButton
-        onClick={() => {
-          setZoomAxis(zoomAxis === "X" ? "Y" : "X");
-        }}
-        title={
-          zoomAxis === "X"
-            ? "Switch to vertical zoom"
-            : "Switch to horizontal zoom (you can also hold Ctrl key)"
-        }
-      >
-
-        <TiZoom className="mx-auto  w-5 h-5 inline-block m-0" />
-        {zoomAxis === "Y" ? (
-          <BiMoveVertical className="mx-auto  w-5 h-5 inline-block m-0" />
-        ) : (
-          <>
-            <BiMoveHorizontal className="mx-auto  w-5 h-5 inline-block m-0" />
-          </>
-        )}
-        </TaxButton>*/}
         <TaxButton
           onClick={() => {
             zoomReset();

--- a/taxonium_component/src/hooks/useGetDynamicData.tsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.tsx
@@ -33,7 +33,7 @@ function useGetDynamicData(backend, colorBy, viewState, config, xType) {
             boundsForQueries.min_y + viewState.real_height / 2 ||
           viewState.max_y >
             boundsForQueries.max_y - viewState.real_height / 2 ||
-          Math.abs(viewState.zoom - boundsForQueries.zoom) > 0.5))
+          Math.abs(viewState.zoom[1] - boundsForQueries.zoom) > 0.5))
     ) {
       if (window.log) {
         console.log([viewState.min_x, boundsForQueries.min_x]);
@@ -46,7 +46,7 @@ function useGetDynamicData(backend, colorBy, viewState, config, xType) {
         max_x: viewState.max_x + viewState.real_width,
         min_y: viewState.min_y - viewState.real_height,
         max_y: viewState.max_y + viewState.real_height,
-        zoom: viewState.zoom,
+        zoom: viewState.zoom[1],
         xType: xType,
       };
 

--- a/taxonium_component/src/hooks/useLayers.tsx
+++ b/taxonium_component/src/hooks/useLayers.tsx
@@ -38,9 +38,7 @@ const useLayers = ({
   hoverInfo,
   colorBy,
   xType,
-  modelMatrix,
   selectedDetails,
-  xzoom,
   settings,
   isCurrentlyOutsideBounds,
   config,
@@ -173,7 +171,6 @@ const useLayers = ({
     pickable: true,
     radiusUnits: "pixels",
     onHover: (info) => setHoverInfo(info),
-    modelMatrix: modelMatrix,
     updateTriggers: {
       getFillColor: [detailed_data, getNodeColorField, colorHook],
       getRadius: [settings.nodeSize],
@@ -196,8 +193,6 @@ const useLayers = ({
         : 1,
 
     onHover: (info) => setHoverInfo(info),
-
-    modelMatrix: modelMatrix,
     updateTriggers: {
       getSourcePosition: [detailed_data, xType],
       getTargetPosition: [detailed_data, xType],
@@ -218,7 +213,6 @@ const useLayers = ({
           selectedDetails.nodeDetails.node_id === d.node_id
         ? 2.5
         : 1,
-    modelMatrix: modelMatrix,
     updateTriggers: {
       getSourcePosition: [detailed_data, xType],
       getTargetPosition: [detailed_data, xType],
@@ -290,7 +284,6 @@ const useLayers = ({
       id: "main-selected",
       filled: false,
       stroked: true,
-      modelMatrix,
 
       getLineColor: [0, 0, 0],
       getPosition: (d) => {
@@ -311,7 +304,6 @@ const useLayers = ({
       id: "main-hovered",
       filled: false,
       stroked: true,
-      modelMatrix,
 
       getLineColor: [0, 0, 0],
       getPosition: (d) => {
@@ -338,7 +330,6 @@ const useLayers = ({
       getTextAnchor: "end",
       getAlignmentBaseline: "center",
       getSize: 11,
-      modelMatrix: modelMatrix,
       updateTriggers: {
         getPosition: [getX],
       },
@@ -358,7 +349,7 @@ const useLayers = ({
     );
   }
 
-  const proportionalToNodesOnScreen = config.num_tips / 2 ** viewState.zoom;
+  const proportionalToNodesOnScreen = config.num_tips / 2 ** viewState.zoom[1];
 
   // If leaves are fewer than max_text_number, add a text layer
   if (
@@ -386,7 +377,6 @@ const useLayers = ({
       getTextAnchor: "start",
       getAlignmentBaseline: "center",
       getSize: data.data.nodes.length < 200 ? 12 : 9.5,
-      modelMatrix: modelMatrix,
       getPixelOffset: [10, 0],
     };
 
@@ -502,7 +492,6 @@ const useLayers = ({
       getFillColor: settings.displaySearchesAsPoints
         ? lineColor
         : [255, 0, 0, 0],
-      modelMatrix: modelMatrix,
       updateTriggers: {
         getPosition: [xType],
       },

--- a/taxonium_component/src/hooks/useTreenomeLayers.tsx
+++ b/taxonium_component/src/hooks/useTreenomeLayers.tsx
@@ -15,26 +15,6 @@ const useTreenomeLayers = (
   selectedDetails
 ) => {
   const myGetPolygonOffset = ({ layerIndex }) => [0, -(layerIndex + 999) * 100];
-  const modelMatrixFixedX = useMemo(() => {
-    return [
-      1 / 2 ** viewState.zoom,
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      0,
-      0,
-      0,
-      1,
-    ];
-  }, [viewState.zoom]);
 
   const variation_padding = useMemo(() => {
     if (!data.data.nodes) {
@@ -150,7 +130,6 @@ const useTreenomeLayers = (
           : [245, 245, 245];
       }
     },
-    modelMatrix: modelMatrixFixedX,
     getSourcePosition: (d) => {
       if (!treenomeState.ntBounds) {
         return [[0, 0]];
@@ -249,7 +228,6 @@ const useTreenomeLayers = (
       }
       return color;
     },
-    modelMatrix: modelMatrixFixedX,
     getSourcePosition: (d) => {
       if (!treenomeState.ntBounds) {
         return [[0, 0]];
@@ -408,7 +386,6 @@ const useTreenomeLayers = (
 
     // data: [ [[-1000, -1000], [-1000, 1000], [1000, 1000], [1000, -1000]] ] ,
     getPolygon: (d) => d,
-    modelMatrix: modelMatrixFixedX,
     lineWidthUnits: "pixels",
     getLineWidth: 0,
     filled: true,
@@ -424,14 +401,12 @@ const useTreenomeLayers = (
     getPolygon: (d) => d.x,
     getFillColor: (d) => d.c,
     getPolygonOffset: myGetPolygonOffset,
-    modelMatrix: modelMatrixFixedX,
   };
 
   const dynamic_browser_background_layer = {
     layerType: "SolidPolygonLayer",
     id: "browser-loaded-dynamic-background",
     data: dynamic_background_data,
-    modelMatrix: modelMatrixFixedX,
     getPolygon: (d) => d.x,
     getFillColor: (d) => [...d.c, 0.2 * 255],
     getPolygonOffset: myGetPolygonOffset,
@@ -450,7 +425,6 @@ const useTreenomeLayers = (
       },
     ],
     getPolygon: (d) => d.x,
-    modelMatrix: modelMatrixFixedX,
     lineWidthUnits: "pixels",
     getLineWidth: 1,
     getLineColor: [100, 100, 100],
@@ -465,7 +439,6 @@ const useTreenomeLayers = (
     id: "browser-loaded-selected-node",
     data: selected_node_data,
     getPolygon: (d) => d.p,
-    modelMatrix: modelMatrixFixedX,
     lineWidthUnits: "pixels",
     getLineWidth: 0.4,
     opacity: 0.1,

--- a/taxonium_component/src/hooks/useView.tsx
+++ b/taxonium_component/src/hooks/useView.tsx
@@ -110,7 +110,9 @@ const useView = ({ settings, deckSize }) => {
   const zoomIncrement = useCallback(
     (increment, axis = "Y") => {
       setViewState((prev) => {
-        const zoom = Array.isArray(prev.zoom) ? [...prev.zoom] : [prev.zoom, prev.zoom];
+        const zoom = Array.isArray(prev.zoom)
+          ? [...prev.zoom]
+          : [prev.zoom, prev.zoom];
         if (axis === "Y") {
           zoom[1] += increment;
         } else {

--- a/taxonium_component/src/hooks/useView.tsx
+++ b/taxonium_component/src/hooks/useView.tsx
@@ -1,86 +1,32 @@
 // @ts-nocheck
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { OrthographicView, OrthographicController } from "@deck.gl/core";
 
-let globalSetZoomAxis = () => {};
 const defaultViewState = {
-  zoom: -2,
+  zoom: [-2, -2],
   target: [window.screen.width < 600 ? 500 : 1400, 1000],
   pitch: 0,
   bearing: 0,
-  minimap: { zoom: -3, target: [250, 1000] },
-  "browser-main": { zoom: -2, target: [0, 1000] },
-  "browser-axis": { zoom: -2, target: [0, 1000] },
+  minimap: { zoom: [-3, -3], target: [250, 1000] },
+  "browser-main": { zoom: [-2, -2], target: [0, 1000] },
+  "browser-axis": { zoom: [-2, -2], target: [0, 1000] },
 };
 
-const useView = ({
-  settings,
-  deckSize,
-  deckRef,
-  jbrowseRef,
-  mouseDownIsMinimap,
-}) => {
-  const [zoomAxis, setZoomAxis] = useState("Y");
-  const [xzoom, setXzoom] = useState(window.screen.width < 600 ? -1 : 0);
+const useView = ({ settings, deckSize }) => {
   const [viewState, setViewState] = useState(defaultViewState);
   const [mouseXY, setMouseXY] = useState([0, 0]);
 
-  // expose setter
-  globalSetZoomAxis = setZoomAxis;
-
-  // side-effect for treenomeEnabled toggling xzoom
-  useEffect(() => {
-    setXzoom(
-      window.screen.width < 600 ? -1 : settings.treenomeEnabled ? -1 : 0
-    );
-  }, [settings.treenomeEnabled]);
-
-  // --- Refs to hold latest values for callbacks ---
-  const zoomAxisRef = useRef(zoomAxis);
-  const xzoomRef = useRef(xzoom);
-  const viewStateRef = useRef(viewState);
-  const mouseXYRef = useRef(mouseXY);
-  const deckSizeRef = useRef(deckSize);
-
-  useEffect(() => {
-    zoomAxisRef.current = zoomAxis;
-  }, [zoomAxis]);
-  useEffect(() => {
-    xzoomRef.current = xzoom;
-  }, [xzoom]);
-  useEffect(() => {
-    viewStateRef.current = viewState;
-  }, [viewState]);
-  useEffect(() => {
-    mouseXYRef.current = mouseXY;
-  }, [mouseXY]);
-  useEffect(() => {
-    deckSizeRef.current = deckSize;
-  }, [deckSize]);
-
-  // baseViewState memo
-  const baseViewState = useMemo(
-    () => ({
-      ...viewState,
-      "browser-main": { zoom: 0, target: [0, 0] },
-      "browser-axis": { zoom: 0, target: [0, 0] },
-    }),
-    [viewState]
-  );
-
-  // controllerProps memo
   const controllerProps = useMemo(
     () => ({
       type: OrthographicController,
-      zoomAxis,
+      zoomAxis: "Y",
       scrollZoom: true,
       smooth: true,
       doubleClickZoom: false,
     }),
-    [zoomAxis]
+    []
   );
 
-  // views memo
   const views = useMemo(() => {
     const vs = [];
     if (settings.minimapEnabled && !settings.treenomeEnabled) {
@@ -134,143 +80,60 @@ const useView = ({
     return vs;
   }, [controllerProps, viewState, settings]);
 
-  // modelMatrix memo
-  const modelMatrix = useMemo(
-    () => [
-      1 / 2 ** (viewState.zoom - xzoom),
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      0,
-      0,
-      0,
-      1,
-    ],
-    [viewState.zoom, xzoom]
+  const computeBounds = useCallback(
+    (vs) => {
+      if (!deckSize) return vs;
+      const zoom = Array.isArray(vs.zoom) ? vs.zoom : [vs.zoom, vs.zoom];
+      const real_width = deckSize.width / 2 ** zoom[0];
+      const real_height = deckSize.height / 2 ** zoom[1];
+      vs.real_width = real_width;
+      vs.real_height = real_height;
+      vs.min_x = vs.target[0] - real_width / 2;
+      vs.max_x = vs.target[0] + real_width / 2;
+      vs.min_y = vs.target[1] - real_height / 2;
+      vs.max_y = vs.target[1] + real_height / 2;
+      vs.minimap = { zoom: [-3, -3], target: [250, 1000] };
+      return vs;
+    },
+    [deckSize]
   );
 
-  // onViewStateChange using refs
   const onViewStateChange = useCallback(
-    ({
-      viewState: newViewState,
-      interactionState,
-      viewId,
-      oldViewState,
-      basicTarget,
-      overrideZoomAxis,
-      specialMinimap,
-    }) => {
-      const dz = deckSizeRef.current;
-      if (!dz) return;
-
-      const localZoomAxis = overrideZoomAxis || zoomAxisRef.current;
-      if (viewId === "minimap") return;
-
-      const oldScaleY = 2 ** oldViewState.zoom;
-      const newScaleY = 2 ** newViewState.zoom;
-      if (mouseDownIsMinimap && !specialMinimap && oldScaleY === newScaleY) {
-        return;
-      }
-
-      let newScaleX = 2 ** xzoomRef.current;
-      if (basicTarget) {
-        newViewState.target[0] =
-          (newViewState.target[0] / newScaleY) * newScaleX;
-      } else if (oldScaleY !== newScaleY) {
-        if (localZoomAxis === "Y") {
-          newViewState.target[0] =
-            (oldViewState.target[0] / newScaleY) * oldScaleY;
-        } else {
-          const diff = newViewState.zoom - oldViewState.zoom;
-          setXzoom((old) => old + diff);
-          newScaleX = 2 ** (xzoomRef.current + diff);
-          newViewState.zoom = oldViewState.zoom;
-          newViewState.target[0] =
-            (oldViewState.target[0] / oldScaleY) * newScaleY;
-        }
-      }
-
-      newViewState.target = [...newViewState.target];
-      newViewState.real_height = dz.height / newScaleY;
-      newViewState.real_width = dz.width / newScaleX;
-      newViewState.real_target = [...newViewState.target];
-      newViewState.real_target[0] =
-        (newViewState.real_target[0] * newScaleY) / newScaleX;
-
-      const nw = [
-        newViewState.real_target[0] - newViewState.real_width / 2,
-        newViewState.real_target[1] - newViewState.real_height / 2,
-      ];
-      const se = [
-        newViewState.real_target[0] + newViewState.real_width / 2,
-        newViewState.real_target[1] + newViewState.real_height / 2,
-      ];
-      newViewState.min_x = nw[0];
-      newViewState.max_x = se[0];
-      newViewState.min_y = nw[1];
-      newViewState.max_y = se[1];
-      newViewState.minimap = { zoom: -3, target: [250, 1000] };
-
-      if (jbrowseRef.current) {
-        const yBound = jbrowseRef.current.children[0].children[0].clientHeight;
-        const xBound =
-          jbrowseRef.current.children[0].children[0].offsetParent.offsetParent
-            .offsetLeft;
-        const [mx, my] = mouseXYRef.current;
-        if ((mx > xBound && my < yBound) || mx < 0 || my < 0) {
-          if (!basicTarget && viewId) return;
-        }
-      }
-
-      if (viewId === "main" || viewId === "main-overlay" || !viewId) {
-        newViewState["browser-main"] = {
-          ...viewStateRef.current["browser-main"],
-          zoom: newViewState.zoom,
-          target: [
-            viewStateRef.current["browser-main"].target[0],
-            newViewState.target[1],
-          ],
-        };
-      }
-
-      setViewState(newViewState);
-      return newViewState;
+    ({ viewState: newVS }) => {
+      const updated = computeBounds({ ...viewState, ...newVS });
+      setViewState(updated);
+      return updated;
     },
-    [jbrowseRef, mouseDownIsMinimap]
+    [computeBounds, viewState]
   );
 
   const zoomIncrement = useCallback(
-    (increment, overrideZoomAxis) => {
-      const newVS = { ...viewStateRef.current };
-      newVS.zoom += increment;
-      onViewStateChange({
-        viewState: newVS,
-        interactionState: "isZooming",
-        oldViewState: viewStateRef.current,
-        overrideZoomAxis,
+    (increment, axis = "Y") => {
+      setViewState((prev) => {
+        const zoom = Array.isArray(prev.zoom) ? [...prev.zoom] : [prev.zoom, prev.zoom];
+        if (axis === "Y") {
+          zoom[1] += increment;
+        } else {
+          zoom[0] += increment;
+        }
+        return computeBounds({ ...prev, zoom });
       });
     },
-    [onViewStateChange]
+    [computeBounds]
   );
 
   const zoomReset = useCallback(() => {
-    const newVS = { ...defaultViewState };
-    setXzoom(0);
-    setViewState(newVS);
-    onViewStateChange({
-      viewState: newVS,
-      interactionState: "isZooming",
-      oldViewState: newVS,
-    });
-  }, [onViewStateChange]);
+    setViewState(computeBounds({ ...defaultViewState }));
+  }, [computeBounds]);
+
+  const baseViewState = useMemo(
+    () => ({
+      ...viewState,
+      "browser-main": { zoom: [0, 0], target: [0, 0] },
+      "browser-axis": { zoom: [0, 0], target: [0, 0] },
+    }),
+    [viewState]
+  );
 
   return useMemo(
     () => ({
@@ -278,28 +141,14 @@ const useView = ({
       setViewState,
       onViewStateChange,
       views,
-      zoomAxis,
-      setZoomAxis,
-      modelMatrix,
+      zoomAxis: "Y",
       zoomIncrement,
-      xzoom,
       mouseXY,
       setMouseXY,
       baseViewState,
       zoomReset,
     }),
-    [
-      viewState,
-      onViewStateChange,
-      views,
-      zoomAxis,
-      modelMatrix,
-      zoomIncrement,
-      xzoom,
-      mouseXY,
-      baseViewState,
-      zoomReset,
-    ]
+    [viewState, views, zoomIncrement, mouseXY, baseViewState, zoomReset]
   );
 };
 


### PR DESCRIPTION
## Summary
- refactor view handling to always use `[x,y]` zoom with a fixed Y axis controller
- drop modelMatrix-based scaling in layers and treenome helpers
- clean up deck buttons and stories for new props
- update dynamic data queries for new zoom format

## Testing
- `npm run check-types`