### PR TITLE
Move bounds calculation to dynamic hook

### DIFF
--- a/taxonium_component/package-lock.json
+++ b/taxonium_component/package-lock.json
@@ -43,7 +43,7 @@
         "react-spinners": "^0.17.0",
         "react-tabs": "^6.1.0",
         "react-tooltip": "^5.28.1",
-        "readable-web-to-node-stream": "^5.0.0",
+        "readable-web-to-node-stream": "^4.0.0",
         "scale-color-perceptual": "^1.1.2",
         "storybook": "^8.6.12",
         "stream-json": "^1.9.1",
@@ -11699,9 +11699,9 @@
       "license": "MIT"
     },
     "node_modules/readable-web-to-node-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-5.0.0.tgz",
-      "integrity": "sha512-BYDNE3p8516xCm5yCkwXt4lTLSjYAFzPtMot7dwpNz3tb5nwcLUfq9N1yiaAYFOA+9BVKi13aOIUPdv96t/Xzg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-4.0.0.tgz",
+      "integrity": "sha512-jpaI1nM4jLxFoIjqyxGhMEnvOOjDSCCnKjSltefZSS4LpR5EUotxqCsxKbAsza1DP4zNlNJN3NJwLZlIXsAXwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/taxonium_component/package.json
+++ b/taxonium_component/package.json
@@ -72,7 +72,7 @@
     "react-spinners": "^0.17.0",
     "react-tabs": "^6.1.0",
     "react-tooltip": "^5.28.1",
-    "readable-web-to-node-stream": "^5.0.0",
+    "readable-web-to-node-stream": "^4.0.0",
     "scale-color-perceptual": "^1.1.2",
     "storybook": "^8.6.12",
     "stream-json": "^1.9.1",

--- a/taxonium_component/src/Deck.jsx
+++ b/taxonium_component/src/Deck.jsx
@@ -72,7 +72,7 @@ function Deck({
   // Treenome state
   const setMouseXY = useCallback(
     (info) => view.setMouseXY([info.x, info.y]),
-    [view],
+    [view]
   );
   const [treenomeReferenceInfo, setTreenomeReferenceInfo] = useState(null);
 
@@ -98,7 +98,7 @@ function Deck({
         mouseDownPos.current &&
         Math.sqrt(
           Math.pow(mouseDownPos.current[0] - event.clientX, 2) +
-            Math.pow(mouseDownPos.current[1] - event.clientY, 2),
+            Math.pow(mouseDownPos.current[1] - event.clientY, 2)
         ) > pan_threshold
       ) {
         return false;
@@ -149,13 +149,7 @@ function Deck({
         });
       }
     },
-    [
-      selectedDetails,
-      mouseDownIsMinimap,
-      viewState,
-      onViewStateChange,
-      deckRef,
-    ],
+    [selectedDetails, mouseDownIsMinimap, viewState, onViewStateChange, deckRef]
   );
 
   const [hoverInfo, setHoverInfoRaw] = useState(null);
@@ -173,7 +167,7 @@ function Deck({
         hoverDetails.clearNodeDetails();
       }
     },
-    [hoverDetails],
+    [hoverDetails]
   );
 
   const { layers, layerFilter, keyStuff, triggerSVGdownload } = useLayers({

--- a/taxonium_component/src/Deck.jsx
+++ b/taxonium_component/src/Deck.jsx
@@ -180,6 +180,7 @@ function Deck({
     data,
     search,
     viewState,
+    deckSize,
     colorHook,
     setHoverInfo,
     hoverInfo,

--- a/taxonium_component/src/Taxonium.jsx
+++ b/taxonium_component/src/Taxonium.jsx
@@ -118,7 +118,14 @@ function Taxonium({
   );
 
   const { data, boundsForQueries, isCurrentlyOutsideBounds } =
-    useGetDynamicData(backend, colorBy, view.viewState, config, xType, deckSize);
+    useGetDynamicData(
+      backend,
+      colorBy,
+      view.viewState,
+      config,
+      xType,
+      deckSize
+    );
 
   const perNodeFunctions = usePerNodeFunctions(data, config);
 

--- a/taxonium_component/src/Taxonium.jsx
+++ b/taxonium_component/src/Taxonium.jsx
@@ -118,7 +118,7 @@ function Taxonium({
   );
 
   const { data, boundsForQueries, isCurrentlyOutsideBounds } =
-    useGetDynamicData(backend, colorBy, view.viewState, config, xType);
+    useGetDynamicData(backend, colorBy, view.viewState, config, xType, deckSize);
 
   const perNodeFunctions = usePerNodeFunctions(data, config);
 

--- a/taxonium_component/src/hooks/useGetDynamicData.jsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import computeBounds from "../utils/computeBounds";
 
 const DEBOUNCE_TIME = 100;
 const CHECK_AGAIN_TIME = 100;
@@ -10,7 +11,8 @@ function addNodeLookup(data) {
   console.log("cc");
   return output;
 }
-function useGetDynamicData(backend, colorBy, viewState, config, xType) {
+
+function useGetDynamicData(backend, colorBy, viewState, config, xType, deckSize) {
   const { queryNodes } = backend;
   const [dynamicData, setDynamicData] = useState({
     status: "not_started",
@@ -22,51 +24,51 @@ function useGetDynamicData(backend, colorBy, viewState, config, xType) {
   let [timeoutRef, setTimeoutRef] = useState(null);
 
   useEffect(() => {
+    const vs = computeBounds({ ...viewState }, deckSize);
     if (
       !boundsForQueries ||
       xType !== boundsForQueries.xType ||
       (true &&
-        (viewState.min_x < boundsForQueries.min_x + viewState.real_width / 2 ||
-          viewState.max_x > boundsForQueries.max_x - viewState.real_width / 2 ||
-          viewState.min_y <
-            boundsForQueries.min_y + viewState.real_height / 2 ||
-          viewState.max_y >
-            boundsForQueries.max_y - viewState.real_height / 2 ||
-          Math.abs(viewState.zoom[1] - boundsForQueries.zoom[1]) > 0.5))
+        (vs.min_x < boundsForQueries.min_x + vs.real_width / 2 ||
+          vs.max_x > boundsForQueries.max_x - vs.real_width / 2 ||
+          vs.min_y < boundsForQueries.min_y + vs.real_height / 2 ||
+          vs.max_y > boundsForQueries.max_y - vs.real_height / 2 ||
+          Math.abs(vs.zoom[1] - boundsForQueries.zoom[1]) > 0.5))
     ) {
       if (window.log) {
-        console.log([viewState.min_x, boundsForQueries.min_x]);
+        console.log([vs.min_x, boundsForQueries ? boundsForQueries.min_x : null]);
       }
-      console.log("VIEWSTATE", viewState);
+      console.log("VIEWSTATE", vs);
 
       console.log("updating parameters to query");
 
       const newBoundForQuery = {
-        min_x: viewState.min_x - viewState.real_width,
-        max_x: viewState.max_x + viewState.real_width,
-        min_y: viewState.min_y - viewState.real_height,
-        max_y: viewState.max_y + viewState.real_height,
-        zoom: viewState.zoom,
+        min_x: vs.min_x - vs.real_width,
+        max_x: vs.max_x + vs.real_width,
+        min_y: vs.min_y - vs.real_height,
+        max_y: vs.max_y + vs.real_height,
+        zoom: vs.zoom,
         xType: xType,
       };
 
       setBoundsForQueries(newBoundForQuery);
       console.log("updating bounds", newBoundForQuery);
     }
-  }, [viewState, boundsForQueries, triggerRefresh, xType]);
+  }, [viewState, boundsForQueries, triggerRefresh, xType, deckSize]);
 
-  const isCurrentlyOutsideBounds = useMemo(
-    () =>
-      viewState.min_x &&
+  const isCurrentlyOutsideBounds = useMemo(() => {
+    const vs = computeBounds({ ...viewState }, deckSize);
+    return (
+      vs.min_x &&
       dynamicData &&
       dynamicData.lastBounds &&
       dynamicData.lastBounds.min_x &&
-      (viewState.min_x < dynamicData.lastBounds.min_x ||
-        viewState.max_x > dynamicData.lastBounds.max_x ||
-        viewState.min_y < dynamicData.lastBounds.min_y ||
-        viewState.max_y > dynamicData.lastBounds.max_y),
-    [viewState, dynamicData]
-  );
+      (vs.min_x < dynamicData.lastBounds.min_x ||
+        vs.max_x > dynamicData.lastBounds.max_x ||
+        vs.min_y < dynamicData.lastBounds.min_y ||
+        vs.max_y > dynamicData.lastBounds.max_y)
+    );
+  }, [viewState, dynamicData, deckSize]);
 
   useEffect(() => {
     if (config.title !== "loading") {

--- a/taxonium_component/src/hooks/useGetDynamicData.jsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.jsx
@@ -12,7 +12,14 @@ function addNodeLookup(data) {
   return output;
 }
 
-function useGetDynamicData(backend, colorBy, viewState, config, xType, deckSize) {
+function useGetDynamicData(
+  backend,
+  colorBy,
+  viewState,
+  config,
+  xType,
+  deckSize
+) {
   const { queryNodes } = backend;
   const [dynamicData, setDynamicData] = useState({
     status: "not_started",
@@ -36,7 +43,10 @@ function useGetDynamicData(backend, colorBy, viewState, config, xType, deckSize)
           Math.abs(vs.zoom[1] - boundsForQueries.zoom[1]) > 0.5))
     ) {
       if (window.log) {
-        console.log([vs.min_x, boundsForQueries ? boundsForQueries.min_x : null]);
+        console.log([
+          vs.min_x,
+          boundsForQueries ? boundsForQueries.min_x : null,
+        ]);
       }
       console.log("VIEWSTATE", vs);
 

--- a/taxonium_component/src/hooks/useLayers.jsx
+++ b/taxonium_component/src/hooks/useLayers.jsx
@@ -68,7 +68,7 @@ const useLayers = ({
     treenomeReferenceInfo,
     setTreenomeReferenceInfo,
     selectedDetails,
-    isCurrentlyOutsideBounds,
+    isCurrentlyOutsideBounds
   );
   layers.push(...treenomeLayers);
 
@@ -94,11 +94,11 @@ const useLayers = ({
 
   const clade_data = useMemo(() => {
     const initial_data = detailed_data.nodes.filter(
-      (n) => n.clades && n.clades[clade_accessor],
+      (n) => n.clades && n.clades[clade_accessor]
     );
 
     const rev_sorted_by_num_tips = initial_data.sort(
-      (a, b) => b.num_tips - a.num_tips,
+      (a, b) => b.num_tips - a.num_tips
     );
 
     // pick top settings.minTipsForCladeText
@@ -126,7 +126,7 @@ const useLayers = ({
       (node) =>
         node.is_tip ||
         (node.is_tip === undefined && node.num_tips === 1) ||
-        settings.displayPointsForInternalNodes,
+        settings.displayPointsForInternalNodes
     );
   }, [detailed_data, settings.displayPointsForInternalNodes]);
 
@@ -136,14 +136,14 @@ const useLayers = ({
           (node) =>
             node.is_tip ||
             (node.is_tip === undefined && node.num_tips === 1) ||
-            settings.displayPointsForInternalNodes,
+            settings.displayPointsForInternalNodes
         )
       : [];
   }, [base_data, settings.displayPointsForInternalNodes]);
 
   const computedViewState = useMemo(
     () => computeBounds({ ...viewState }, deckSize),
-    [viewState, deckSize],
+    [viewState, deckSize]
   );
 
   const outer_bounds = [
@@ -208,9 +208,9 @@ const useLayers = ({
       d === (hoverInfo && hoverInfo.object)
         ? 3
         : selectedDetails.nodeDetails &&
-            selectedDetails.nodeDetails.node_id === d.node_id
-          ? 3.5
-          : 1,
+          selectedDetails.nodeDetails.node_id === d.node_id
+        ? 3.5
+        : 1,
 
     onHover: (info) => setHoverInfo(info),
 
@@ -232,9 +232,9 @@ const useLayers = ({
       d === (hoverInfo && hoverInfo.object)
         ? 2
         : selectedDetails.nodeDetails &&
-            selectedDetails.nodeDetails.node_id === d.node_id
-          ? 2.5
-          : 1,
+          selectedDetails.nodeDetails.node_id === d.node_id
+        ? 2.5
+        : 1,
     modelMatrix: modelMatrix,
     updateTriggers: {
       getSourcePosition: [detailed_data, xType],
@@ -371,7 +371,7 @@ const useLayers = ({
       fillin_scatter_layer,
       clade_label_layer,
       selectedLayer,
-      hoveredLayer,
+      hoveredLayer
     );
   }
 
@@ -391,7 +391,7 @@ const useLayers = ({
       data: data.data.nodes.filter((node) =>
         settings.displayTextForInternalNodes
           ? true
-          : node.is_tip || (node.is_tip === undefined && node.num_tips === 1),
+          : node.is_tip || (node.is_tip === undefined && node.num_tips === 1)
       ),
       getPosition: (d) => [getX(d), d.y],
       getText: (d) => d[config.name_accessor],
@@ -574,7 +574,7 @@ const useLayers = ({
 
       return first_bit;
     },
-    [isCurrentlyOutsideBounds],
+    [isCurrentlyOutsideBounds]
   );
 
   const processedLayers = layers
@@ -600,7 +600,7 @@ const useLayers = ({
 
   const { triggerSVGdownload } = getSVGfunction(
     layers.filter((x) => x !== null),
-    viewState,
+    viewState
   );
 
   return { layers: processedLayers, layerFilter, keyStuff, triggerSVGdownload };

--- a/taxonium_component/src/hooks/useLayers.jsx
+++ b/taxonium_component/src/hooks/useLayers.jsx
@@ -7,6 +7,7 @@ import {
 } from "@deck.gl/layers";
 
 import { useMemo, useCallback } from "react";
+import computeBounds from "../utils/computeBounds";
 import useTreenomeLayers from "./useTreenomeLayers";
 import getSVGfunction from "../utils/deckglToSvg";
 
@@ -32,6 +33,7 @@ const useLayers = ({
   data,
   search,
   viewState,
+  deckSize,
   colorHook,
   setHoverInfo,
   hoverInfo,
@@ -139,6 +141,11 @@ const useLayers = ({
       : [];
   }, [base_data, settings.displayPointsForInternalNodes]);
 
+  const computedViewState = useMemo(
+    () => computeBounds({ ...viewState }, deckSize),
+    [viewState, deckSize],
+  );
+
   const outer_bounds = [
     [-100000, -100000],
     [100000, -100000],
@@ -147,10 +154,22 @@ const useLayers = ({
     [-100000, -100000],
   ];
   const inner_bounds = [
-    [viewState.min_x, viewState.min_y < -1000 ? -1000 : viewState.min_y],
-    [viewState.max_x, viewState.min_y < -1000 ? -1000 : viewState.min_y],
-    [viewState.max_x, viewState.max_y > 10000 ? 10000 : viewState.max_y],
-    [viewState.min_x, viewState.max_y > 10000 ? 10000 : viewState.max_y],
+    [
+      computedViewState.min_x,
+      computedViewState.min_y < -1000 ? -1000 : computedViewState.min_y,
+    ],
+    [
+      computedViewState.max_x,
+      computedViewState.min_y < -1000 ? -1000 : computedViewState.min_y,
+    ],
+    [
+      computedViewState.max_x,
+      computedViewState.max_y > 10000 ? 10000 : computedViewState.max_y,
+    ],
+    [
+      computedViewState.min_x,
+      computedViewState.max_y > 10000 ? 10000 : computedViewState.max_y,
+    ],
   ];
 
   const bound_contour = [[outer_bounds, inner_bounds]];

--- a/taxonium_component/src/hooks/useView.jsx
+++ b/taxonium_component/src/hooks/useView.jsx
@@ -84,33 +84,10 @@ const useView = ({ settings,  deckSize }) => {
     return vs;
   }, [controllerProps, viewState, settings]);
 
-  const computeBounds = useCallback(
-    (vs) => {
-      if (!deckSize) return vs;
-      const zoom = Array.isArray(vs.zoom) ? vs.zoom : [vs.zoom, vs.zoom];
-      const real_width = deckSize.width / 2 ** zoom[0];
-      const real_height = deckSize.height / 2 ** zoom[1];
-      vs.real_width = real_width;
-      vs.real_height = real_height;
-      vs.min_x = vs.target[0] - real_width / 2;
-      vs.max_x = vs.target[0] + real_width / 2;
-      vs.min_y = vs.target[1] - real_height / 2;
-      vs.max_y = vs.target[1] + real_height / 2;
-      vs.minimap = { zoom: [-3, -3], target: [250, 1000] };
-      return vs;
-    },
-    [deckSize]
-  );
-
-
   const onViewStateChange = useCallback(({ viewState: newViewState }) => {
-
-
     console.log("onViewStateChange", newViewState);
-    const newerViewState = computeBounds(newViewState);
-    console.log("newerViewState", newerViewState);
-    setViewState(newerViewState);
-    return newerViewState;
+    setViewState(newViewState);
+    return newViewState;
   }, []);
 
   const zoomIncrement = useCallback((increment) => {

--- a/taxonium_component/src/hooks/useView.jsx
+++ b/taxonium_component/src/hooks/useView.jsx
@@ -82,9 +82,13 @@ const useView = ({ settings, deckSize }) => {
     return vs;
   }, [controllerProps, viewState, settings]);
 
-  const onViewStateChange = useCallback(({ viewState: newViewState }) => {
+  const onViewStateChange = useCallback(({ viewState: newViewState, viewId }) => {
+   
+    
     console.log("onViewStateChange", newViewState);
+    newViewState.minimap = { zoom: -3, target: [250, 1000] },
     setViewState(newViewState);
+
     return newViewState;
   }, []);
 

--- a/taxonium_component/src/hooks/useView.jsx
+++ b/taxonium_component/src/hooks/useView.jsx
@@ -82,15 +82,16 @@ const useView = ({ settings, deckSize }) => {
     return vs;
   }, [controllerProps, viewState, settings]);
 
-  const onViewStateChange = useCallback(({ viewState: newViewState, viewId }) => {
-   
-    
-    console.log("onViewStateChange", newViewState);
-    newViewState.minimap = { zoom: -3, target: [250, 1000] },
-    setViewState(newViewState);
+  const onViewStateChange = useCallback(
+    ({ viewState: newViewState, viewId }) => {
+      console.log("onViewStateChange", newViewState);
+      (newViewState.minimap = { zoom: -3, target: [250, 1000] }),
+        setViewState(newViewState);
 
-    return newViewState;
-  }, []);
+      return newViewState;
+    },
+    []
+  );
 
   const zoomIncrement = useCallback((increment) => {
     //setViewState((vs) => ({ ...vs, zoom: vs.zoom + increment }));

--- a/taxonium_component/src/hooks/useView.jsx
+++ b/taxonium_component/src/hooks/useView.jsx
@@ -13,9 +13,7 @@ const defaultViewState = {
   "browser-axis": { zoom: -2, target: [0, 1000] },
 };
 
-const useView = ({ settings,  deckSize }) => {
-
-
+const useView = ({ settings, deckSize }) => {
   const [viewState, setViewState] = useState(defaultViewState);
   const [mouseXY, setMouseXY] = useState([0, 0]);
   const [zoomAxis, setZoomAxis] = useState("Y");
@@ -28,7 +26,7 @@ const useView = ({ settings,  deckSize }) => {
       scrollZoom: true,
       zoomAxis: "Y",
     }),
-    [],
+    []
   );
 
   const views = useMemo(() => {
@@ -43,7 +41,7 @@ const useView = ({ settings,  deckSize }) => {
           height: "35%",
           borderWidth: "1px",
           controller: controllerProps,
-        }),
+        })
       );
     }
     if (settings.treenomeEnabled) {
@@ -60,7 +58,7 @@ const useView = ({ settings,  deckSize }) => {
           controller: controllerProps,
           x: "40%",
           width: "60%",
-        }),
+        })
       );
     }
     vs.push(
@@ -69,7 +67,7 @@ const useView = ({ settings,  deckSize }) => {
         controller: controllerProps,
         width: settings.treenomeEnabled ? "40%" : "100%",
         initialViewState: viewState,
-      }),
+      })
     );
     if (settings.treenomeEnabled) {
       vs.push(
@@ -78,7 +76,7 @@ const useView = ({ settings,  deckSize }) => {
           controller: controllerProps,
           width: "100%",
           initialViewState: viewState,
-        }),
+        })
       );
     }
     return vs;

--- a/taxonium_component/src/utils/computeBounds.js
+++ b/taxonium_component/src/utils/computeBounds.js
@@ -1,0 +1,13 @@
+export default function computeBounds(vs, deckSize) {
+  if (!deckSize) return vs;
+  const zoom = Array.isArray(vs.zoom) ? vs.zoom : [vs.zoom, vs.zoom];
+  const real_width = deckSize.width / 2 ** zoom[0];
+  const real_height = deckSize.height / 2 ** zoom[1];
+  vs.real_width = real_width;
+  vs.real_height = real_height;
+  vs.min_x = vs.target[0] - real_width / 2;
+  vs.max_x = vs.target[0] + real_width / 2;
+  vs.min_y = vs.target[1] - real_height / 2;
+  vs.max_y = vs.target[1] + real_height / 2;
+  return vs;
+}

--- a/taxonium_component/vite.config.js
+++ b/taxonium_component/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
-import path from "path";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -67,34 +66,9 @@ export default defineConfig({
   },
 
   resolve: {
-    alias: {
-      "vite-plugin-node-polyfills/shims/buffer": path.resolve(
-        __dirname,
-        "node_modules",
-        "vite-plugin-node-polyfills",
-        "shims",
-        "buffer",
-        "dist",
-        "index.cjs"
-      ),
-      "vite-plugin-node-polyfills/shims/global": path.resolve(
-        __dirname,
-        "node_modules",
-        "vite-plugin-node-polyfills",
-        "shims",
-        "global",
-        "dist",
-        "index.cjs"
-      ),
-      "vite-plugin-node-polyfills/shims/process": path.resolve(
-        __dirname,
-        "node_modules",
-        "vite-plugin-node-polyfills",
-        "shims",
-        "process",
-        "dist",
-        "index.cjs"
-      ),
-    },
+    alias:{
+     'process/': 'process/browser',
+    }
+    
   },
 });

--- a/taxonium_component/vite.config.js
+++ b/taxonium_component/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
     nodePolyfills({
       exclude: ["fs"],
       protocolImports: true,
+   
     }),
     react({
       // This ensures React is properly treated as external
@@ -21,7 +22,7 @@ export default defineConfig({
     tailwindcss(),
   ],
   define: {
-    "process.env": { NODE_ENV: JSON.stringify("production") },
+   
   },
 
   build: {
@@ -66,9 +67,9 @@ export default defineConfig({
   },
 
   resolve: {
-    alias:{
-     'process/': 'process/browser',
-    }
+   alias: {
+     'process/': 'process'
+   }
     
   },
 });

--- a/taxonium_component/vite.config.js
+++ b/taxonium_component/vite.config.js
@@ -12,7 +12,6 @@ export default defineConfig({
     nodePolyfills({
       exclude: ["fs"],
       protocolImports: true,
-   
     }),
     react({
       // This ensures React is properly treated as external
@@ -21,9 +20,7 @@ export default defineConfig({
     cssInjectedByJsPlugin(),
     tailwindcss(),
   ],
-  define: {
-   
-  },
+  define: {},
 
   build: {
     lib: {
@@ -67,9 +64,8 @@ export default defineConfig({
   },
 
   resolve: {
-   alias: {
-     'process/': 'process'
-   }
-    
+    alias: {
+      "process/": "process",
+    },
   },
 });


### PR DESCRIPTION
## Summary
- move computeBounds to `src/utils`
- update dynamic data and layers to calculate bounds on demand
- wire deckSize through to `useLayers`
- restore minimap bound drawing

## Testing
- `pre-commit run --files taxonium_component/src/utils/computeBounds.js taxonium_component/src/hooks/useGetDynamicData.jsx taxonium_component/src/hooks/useLayers.jsx taxonium_component/src/Deck.jsx` *(fails: command not found)*