### PR TITLE
Remove unnecessary ts-nocheck directives

### DIFF
--- a/taxonium_component/src/components/ColorPicker.stories.tsx
+++ b/taxonium_component/src/components/ColorPicker.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState } from "react";
 import ColorPicker from "./ColorPicker";
 

--- a/taxonium_component/src/components/DeckButtons.stories.tsx
+++ b/taxonium_component/src/components/DeckButtons.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import { DeckButtons } from "./DeckButtons";
 

--- a/taxonium_component/src/components/DeckSettingsModal.stories.tsx
+++ b/taxonium_component/src/components/DeckSettingsModal.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import DeckSettingsModal from "./DeckSettingsModal";
 

--- a/taxonium_component/src/components/FirefoxWarning.stories.tsx
+++ b/taxonium_component/src/components/FirefoxWarning.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import FirefoxWarning from "./FirefoxWarning";
 
 export default {

--- a/taxonium_component/src/components/JBrowseErrorBoundary.stories.tsx
+++ b/taxonium_component/src/components/JBrowseErrorBoundary.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { JBrowseErrorBoundary } from "./JBrowseErrorBoundary";
 
 export default {

--- a/taxonium_component/src/components/JBrowseErrorBoundary.tsx
+++ b/taxonium_component/src/components/JBrowseErrorBoundary.tsx
@@ -1,24 +1,35 @@
-// @ts-nocheck
 import React from "react";
 import { toast } from "react-hot-toast";
 
-export class JBrowseErrorBoundary extends React.Component {
-  constructor(props) {
+interface JBrowseErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface JBrowseErrorBoundaryState {
+  fileError: boolean;
+  otherError: boolean;
+}
+
+export class JBrowseErrorBoundary extends React.Component<
+  JBrowseErrorBoundaryProps,
+  JBrowseErrorBoundaryState
+> {
+  constructor(props: JBrowseErrorBoundaryProps) {
     super(props);
     this.state = { fileError: false, otherError: false };
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError(error: Error): JBrowseErrorBoundaryState {
     if (
       error.message === "invalid SceneGraph arguments" ||
       error.message === "Invalid array length"
     ) {
-      return { fileError: true };
+      return { fileError: true, otherError: false };
     }
-    return { otherError: true };
+    return { fileError: false, otherError: true };
   }
 
-  componentDidCatch(error, errorInfo) {
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     if (
       error.message === "invalid SceneGraph arguments" ||
       error.message === "Invalid array length"

--- a/taxonium_component/src/components/JBrowsePanel.stories.tsx
+++ b/taxonium_component/src/components/JBrowsePanel.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import JBrowsePanel from "./JBrowsePanel";
 

--- a/taxonium_component/src/components/Key.stories.tsx
+++ b/taxonium_component/src/components/Key.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import Key from "./Key";
 

--- a/taxonium_component/src/components/Key.tsx
+++ b/taxonium_component/src/components/Key.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import prettifyName from "../utils/prettifyName";
 import { useState } from "react";
 import classNames from "classnames";

--- a/taxonium_component/src/components/ListOutputModal.stories.tsx
+++ b/taxonium_component/src/components/ListOutputModal.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import ListOutputModal from "./ListOutputModal";
 

--- a/taxonium_component/src/components/ListOutputModal.tsx
+++ b/taxonium_component/src/components/ListOutputModal.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import Modal from "react-modal";
 import { useState, useEffect } from "react";
 

--- a/taxonium_component/src/components/NodeHoverTip.stories.tsx
+++ b/taxonium_component/src/components/NodeHoverTip.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import NodeHoverTip from "./NodeHoverTip";
 
 export default {

--- a/taxonium_component/src/components/NodeHoverTip.tsx
+++ b/taxonium_component/src/components/NodeHoverTip.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useMemo } from "react";
 
 const fixName = (name) => {
@@ -56,7 +55,7 @@ const NodeHoverTip = ({
   const flip_vert = hoverInfo.y > deckSize.height * 0.66;
   const flip_horiz = hoverInfo.x > deckSize.width * 0.66;
 
-  const style = {
+  const style: React.CSSProperties = {
     position: "absolute",
     zIndex: 1,
     pointerEvents: "none",
@@ -171,7 +170,7 @@ const NodeHoverTip = ({
             </div>
           </div>
         )}
-      {window.show_ids ? (
+      {(window as any).show_ids ? (
         <div className="mt-3 text-xs text-gray-400">{hoveredNode.node_id}</div>
       ) : null}
     </div>

--- a/taxonium_component/src/components/SearchDisplayToggle.stories.tsx
+++ b/taxonium_component/src/components/SearchDisplayToggle.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import SearchDisplayToggle from "./SearchDisplayToggle";
 

--- a/taxonium_component/src/components/SearchDisplayToggle.tsx
+++ b/taxonium_component/src/components/SearchDisplayToggle.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from "react";
 import { toast } from "react-hot-toast";
 import { FaCircle, FaRegCircle } from "react-icons/fa";

--- a/taxonium_component/src/components/SearchItem.stories.tsx
+++ b/taxonium_component/src/components/SearchItem.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import SearchItem from "./SearchItem";
 

--- a/taxonium_component/src/components/SearchPanel.stories.tsx
+++ b/taxonium_component/src/components/SearchPanel.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import SearchPanel from "./SearchPanel";
 

--- a/taxonium_component/src/components/SearchTopLayerItem.stories.tsx
+++ b/taxonium_component/src/components/SearchTopLayerItem.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import SearchTopLayerItem from "./SearchTopLayerItem";
 

--- a/taxonium_component/src/components/SnapshotButton.stories.tsx
+++ b/taxonium_component/src/components/SnapshotButton.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import SnapshotButton from "./SnapshotButton";
 

--- a/taxonium_component/src/components/TaxButton.stories.tsx
+++ b/taxonium_component/src/components/TaxButton.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import TaxButton from "./TaxButton";
 import { FaSearch, FaCamera, FaHome, FaCog } from "react-icons/fa";

--- a/taxonium_component/src/components/TreenomeButtons.stories.tsx
+++ b/taxonium_component/src/components/TreenomeButtons.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import { TreenomeButtons } from "./TreenomeButtons";
 

--- a/taxonium_component/src/components/TreenomeModal.stories.tsx
+++ b/taxonium_component/src/components/TreenomeModal.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { fn } from "@storybook/test";
 import TreenomeModal from "./TreenomeModal";
 

--- a/taxonium_component/src/components/TreenomeMutationHoverTip.stories.tsx
+++ b/taxonium_component/src/components/TreenomeMutationHoverTip.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import TreenomeMutationHoverTip from "./TreenomeMutationHoverTip";
 
 export default {

--- a/taxonium_component/src/components/TreenomeMutationHoverTip.tsx
+++ b/taxonium_component/src/components/TreenomeMutationHoverTip.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const TreenomeMutationHoverTip = ({
   hoverInfo,
   hoverDetails,

--- a/taxonium_component/src/hooks/useColor.tsx
+++ b/taxonium_component/src/hooks/useColor.tsx
@@ -1,18 +1,17 @@
-// @ts-nocheck
 import { useCallback, useMemo } from "react";
 import scale from "scale-color-perceptual";
-import { scaleLinear } from "d3-scale";
+import { scaleLinear, ScaleLinear } from "d3-scale";
 
 let rgb_cache = {};
 
 const useColor = (config, colorMapping, colorByField) => {
   const colorScales = useMemo(() => {
-    const scales = {};
+    const scales: { colorRamp?: ScaleLinear<number, string> } = {};
     if (config.colorRamps && config.colorRamps[colorByField]) {
       const { scale: rampScale } = config.colorRamps[colorByField];
       const domain = rampScale.map((d) => d[0]);
       const range = rampScale.map((d) => d[1]);
-      scales.colorRamp = scaleLinear().domain(domain).range(range);
+      scales.colorRamp = scaleLinear<number, string>().domain(domain).range(range);
     }
     return scales;
   }, [config.colorRamps, colorByField]);

--- a/taxonium_component/src/hooks/useColorBy.tsx
+++ b/taxonium_component/src/hooks/useColorBy.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useMemo, useEffect, useCallback } from "react";
 
 let colorCache = {}; // todo do this with state
@@ -27,7 +26,7 @@ function useColorBy(config, query, updateQuery) {
     ? config.colorBy
     : { colorByOptions: [] };
 
-  window.cc = colorCache;
+  (window as any).cc = colorCache;
 
   const setColorByField = useCallback(
     (field) => {

--- a/taxonium_component/src/hooks/useConfig.tsx
+++ b/taxonium_component/src/hooks/useConfig.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState, useEffect } from "react";
 
 const useConfig = (


### PR DESCRIPTION
## Summary
- drop several `// @ts-nocheck` directives from storybooks
- type NodeHoverTip component
- clean up useColor hook typing
- expose color cache in useColorBy safely
- drop ts-nocheck from a few other small modules

## Testing
- `npm run check-types`