### PR TITLE
Remove unused ts-nocheck comments

### DIFF
--- a/taxonium_component/src/components/DeckSettingsModal.tsx
+++ b/taxonium_component/src/components/DeckSettingsModal.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from "react";
 import Modal from "react-modal";
 import ColorPicker from "./ColorPicker";

--- a/taxonium_component/src/components/JBrowsePanel.tsx
+++ b/taxonium_component/src/components/JBrowsePanel.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useMemo, useEffect, useRef, useState } from "react";
 import "@fontsource/roboto";
 //import "@jbrowse/plugin-data-management";

--- a/taxonium_component/src/components/TreenomeButtons.tsx
+++ b/taxonium_component/src/components/TreenomeButtons.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   BiZoomIn,
   BiZoomOut,

--- a/taxonium_component/src/components/TreenomeModal.tsx
+++ b/taxonium_component/src/components/TreenomeModal.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import Modal from "react-modal";
 import { useState } from "react";
 const settingsModalStyle = {

--- a/taxonium_component/src/hooks/useTreenomeLayerData.tsx
+++ b/taxonium_component/src/hooks/useTreenomeLayerData.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useCallback, useMemo, useEffect, useState } from "react";
 
 import workerSpec from "../webworkers/treenomeWorker.js?worker&inline";

--- a/taxonium_component/src/stories/Tax2.stories.tsx
+++ b/taxonium_component/src/stories/Tax2.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState } from "react";
 import Taxonium from "../Taxonium";
 

--- a/taxonium_component/src/stories/Taxonium.stories.tsx
+++ b/taxonium_component/src/stories/Taxonium.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState } from "react";
 import Taxonium from "../Taxonium";
 


### PR DESCRIPTION
## Summary
- remove unnecessary `@ts-nocheck` directives from some Taxonium component files
- keep type checking passing

## Testing
- `npm run check-types`