### PR TITLE
Add check-types workflow

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -1,0 +1,31 @@
+name: TypeScript check-types
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'taxonium_component/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'taxonium_component/**'
+  workflow_dispatch:
+
+jobs:
+  check-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: NODE_OPTIONS='--max-old-space-size=4096' npm install --force
+        working-directory: ./taxonium_component
+
+      - name: Run check-types
+        run: npm run check-types
+        working-directory: ./taxonium_component


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run `npm run check-types` for the `taxonium_component`
- use `npm install --force` instead of Yarn

## Testing
- `npm run check-types`