### PR TITLE
Refactor: tighten typings

### DIFF
--- a/taxonium_component/src/hooks/useBackend.ts
+++ b/taxonium_component/src/hooks/useBackend.ts
@@ -1,14 +1,20 @@
 import useServerBackend from "./useServerBackend";
 import useLocalBackend from "./useLocalBackend";
 
+interface WindowWithAnalytics extends Window {
+  done_ev?: boolean;
+  gtag?: (...args: unknown[]) => void;
+}
+
 function useBackend(backend_url, sid, uploaded_data) {
   const serverBackend = useServerBackend(backend_url, sid);
   const localBackend = useLocalBackend(uploaded_data);
   if (backend_url) {
-    if (!(window as any).done_ev) {
-      (window as any).done_ev = true;
-      if ((window as any).gtag) {
-        (window as any).gtag("event", "backend", {
+    const w = window as WindowWithAnalytics;
+    if (!w.done_ev) {
+      w.done_ev = true;
+      if (w.gtag) {
+        w.gtag("event", "backend", {
           event_category: "backend",
           event_label: backend_url,
         });

--- a/taxonium_component/src/hooks/useColorBy.tsx
+++ b/taxonium_component/src/hooks/useColorBy.tsx
@@ -1,5 +1,9 @@
 import { useMemo, useEffect, useCallback } from "react";
 
+interface WindowWithCc extends Window {
+  cc?: unknown;
+}
+
 let colorCache = {}; // todo do this with state
 let cachedColorByPosition = null; // todo do this with state
 let cachedColorByGene = null; // todo do this with state
@@ -26,7 +30,7 @@ function useColorBy(config, query, updateQuery) {
     ? config.colorBy
     : { colorByOptions: [] };
 
-  (window as any).cc = colorCache;
+  (window as WindowWithCc).cc = colorCache;
 
   const setColorByField = useCallback(
     (field) => {

--- a/taxonium_component/src/hooks/useGetDynamicData.tsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.tsx
@@ -12,6 +12,19 @@ function addNodeLookup(data) {
   return output;
 }
 
+interface NodeData {
+  nodes: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+interface DynamicData {
+  status: string;
+  data: NodeData;
+  base_data?: NodeData;
+  base_data_is_invalid?: boolean;
+  lastBounds?: Record<string, number>;
+}
+
 function useGetDynamicData(
   backend,
   colorBy,
@@ -21,9 +34,9 @@ function useGetDynamicData(
   deckSize
 ) {
   const { queryNodes } = backend;
-  const [dynamicData, setDynamicData] = useState<any>({
+  const [dynamicData, setDynamicData] = useState<DynamicData>({
     status: "not_started",
-    data: [],
+    data: { nodes: [] },
   });
 
   let [boundsForQueries, setBoundsForQueries] = useState(null);
@@ -42,7 +55,7 @@ function useGetDynamicData(
           vs.max_y > boundsForQueries.max_y - vs.real_height / 2 ||
           Math.abs(vs.zoom[1] - boundsForQueries.zoom[1]) > 0.5))
     ) {
-      if ((window as any).log) {
+      if ((window as Window & { log?: boolean }).log) {
         console.log([
           vs.min_x,
           boundsForQueries ? boundsForQueries.min_x : null,

--- a/taxonium_component/src/hooks/useServerBackend.ts
+++ b/taxonium_component/src/hooks/useServerBackend.ts
@@ -206,7 +206,7 @@ function useServerBackend(backend_url, sid) {
         "&sid=" +
         sid;
       axios.get(url).then(function (response) {
-        callback((response as any).err, response.data);
+        callback((response.data as { err?: unknown }).err, response.data);
       });
     },
     [backend_url, sid]

--- a/taxonium_component/src/hooks/useTreenomeAnnotations.tsx
+++ b/taxonium_component/src/hooks/useTreenomeAnnotations.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const useTreenomeAnnotations = (settings) => {
-  // Track list as returned from UCSC API. We don't currently define a
-  // detailed type for this structure, so fall back to `any`.
-  const [trackList, setTrackList] = useState<any>({});
+  // Track list as returned from UCSC API. Keep loosely typed.
+  const [trackList, setTrackList] = useState<Record<string, unknown>>({});
   const baseUrl = "https://hgdownload.soe.ucsc.edu";
 
   async function getTrackList() {
@@ -34,7 +33,7 @@ const useTreenomeAnnotations = (settings) => {
       // The structure returned here is consumed by JBrowse which expects
       // additional fields not described in our local types, so we keep it
       // as a loosely-typed object.
-      const output: any = {
+      const output: Record<string, unknown> = {
         trackId: key,
         name: name,
         assemblyNames: [settings.chromosomeName],
@@ -66,8 +65,9 @@ const useTreenomeAnnotations = (settings) => {
 
   const json = useMemo(() => {
     let allJson = [];
-    for (const key in trackList.wuhCor1) {
-      const track = trackList.wuhCor1[key];
+    const tl = trackList.wuhCor1 as Record<string, any>;
+    for (const key in tl) {
+      const track = tl[key];
       if (!track.bigDataUrl) {
         for (const childKey in track) {
           let childJson = {};

--- a/taxonium_component/src/hooks/useTreenomeState.tsx
+++ b/taxonium_component/src/hooks/useTreenomeState.tsx
@@ -99,8 +99,8 @@ const useTreenomeState = (data, deckRef, view, settings) => {
   }, [settings.treenomeEnabled]);
 
   // Stores either a boolean or a reference to the JBrowse element once it is
-  // detected. We keep the type loose to avoid type errors during detection.
-  const [jbrowseLoaded, setJbrowseLoaded] = useState<any>(false);
+  // detected.
+  const [jbrowseLoaded, setJbrowseLoaded] = useState<HTMLElement | false>(false);
   const [handled, setHandled] = useState(false);
   useEffect(() => {
     if (jbrowseLoaded && !handled) {

--- a/taxonium_component/src/utils/getDefaultQuery.ts
+++ b/taxonium_component/src/utils/getDefaultQuery.ts
@@ -14,7 +14,7 @@ const default_query = {
 };
 
 // first_search is currently unused, but remains for backwards compatibility
-const getDefaultQuery = (first_search?: any) => {
+const getDefaultQuery = () => {
   return { ...default_query };
 };
 

--- a/taxonium_component/src/utils/searchUtil.ts
+++ b/taxonium_component/src/utils/searchUtil.ts
@@ -1,4 +1,19 @@
-export function getDefaultSearch(config: any, key?: string) {
+export interface SearchSpec {
+  key: string;
+  type: string;
+  method: string;
+  text: string;
+  gene: string;
+  position: number;
+  new_residue: string;
+  min_tips: number;
+}
+
+export interface SearchUtilConfig {
+  defaultSearch?: SearchSpec;
+}
+
+export function getDefaultSearch(config: SearchUtilConfig | null, key?: string): SearchSpec {
   if (!key) {
     key = Math.random().toString(36).substring(2, 15);
     console.log("generated key", key);


### PR DESCRIPTION
## Summary
- replace various `any` usages with defined types
- tighten typing around window globals and dynamic data
- enhance view state typing for DeckGL

## Testing
- `npm run check-types`