### PR TITLE
Fix SVG export with initial view

### DIFF
--- a/taxonium_component/src/utils/deckglToSvg.ts
+++ b/taxonium_component/src/utils/deckglToSvg.ts
@@ -1,3 +1,5 @@
+import computeBounds from "./computeBounds";
+
 const getSVGfunction = (layers, viewState) => {
   const accessOrConstant = (accessor, node) => {
     if (typeof accessor === "function") {
@@ -147,7 +149,8 @@ const getSVGfunction = (layers, viewState) => {
     }
     const svgWidth = deckSize.width;
     const svgHeight = deckSize.height;
-    const svgContent = getSVG(layers, viewState, svgWidth, svgHeight);
+    const viewStateWithBounds = computeBounds({ ...viewState }, deckSize);
+    const svgContent = getSVG(layers, viewStateWithBounds, svgWidth, svgHeight);
     if (!svgContent) {
       return;
     }


### PR DESCRIPTION
## Summary
- ensure SVG export can compute bounds on first use

## Testing
- `npm --workspaces=false --prefix taxonium_component run lint`