### PR TITLE
Use typed refs for DeckGL and jbrowse span

### DIFF
--- a/taxonium_component/src/Deck.tsx
+++ b/taxonium_component/src/Deck.tsx
@@ -107,7 +107,7 @@ function Deck({
 
       //console.log("onClickOrMouseMove", event);
 
-      const pickInfo = deckRef.current.pickObject({
+      const pickInfo = deckRef.current?.pickObject({
         x: event.nativeEvent.offsetX,
         y: event.nativeEvent.offsetY,
         radius: 10,

--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -10,6 +10,7 @@ import useColorBy from "./hooks/useColorBy";
 import useNodeDetails from "./hooks/useNodeDetails";
 import useHoverDetails from "./hooks/useHoverDetails";
 import { useMemo, useState, useRef } from "react";
+import type { DeckGLRef } from "@deck.gl/react";
 import useBackend from "./hooks/useBackend";
 import usePerNodeFunctions from "./hooks/usePerNodeFunctions";
 import useConfig from "./hooks/useConfig";
@@ -63,8 +64,8 @@ function Taxonium({
     setAboutEnabled = () => {};
   }
 
-  const deckRef = useRef<any>(null);
-  const jbrowseRef = useRef<any>(null);
+  const deckRef = useRef<DeckGLRef | null>(null);
+  const jbrowseRef = useRef<HTMLSpanElement | null>(null);
   const [mouseDownIsMinimap, setMouseDownIsMinimap] = useState(false);
 
   const [deckSize, setDeckSize] = useState(null);

--- a/taxonium_component/src/hooks/useSnapshot.ts
+++ b/taxonium_component/src/hooks/useSnapshot.ts
@@ -2,8 +2,10 @@ import { useCallback } from "react";
 
 const useSnapshot = (deckRef) => {
   const snapshot = useCallback(() => {
-    let canvas = deckRef.current.deck.canvas;
-    deckRef.current.deck.redraw(true);
+    const deck = deckRef.current?.deck;
+    if (!deck) return;
+    const canvas = deck.canvas;
+    deck.redraw(true);
     let a = document.createElement("a");
 
     a.href = canvas


### PR DESCRIPTION
## Summary
- type deckRef as `DeckGLRef` and handle null
- type jbrowseRef as `HTMLSpanElement`
- guard against null refs in `Deck.tsx` and `useSnapshot`

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test` *(fails: Missing script)*