### PR TITLE
Fix bounds check for zero min_x

### DIFF
--- a/taxonium_component/src/hooks/useGetDynamicData.test.ts
+++ b/taxonium_component/src/hooks/useGetDynamicData.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { isOutsideBounds } from "./useGetDynamicData";
+
+describe("isOutsideBounds", () => {
+  it("handles zero min_x correctly", () => {
+    const vs = { min_x: 0, max_x: 5, min_y: 0, max_y: 5 } as Record<string, number>;
+    const dynamicData = {
+      lastBounds: { min_x: 10, max_x: 20, min_y: -10, max_y: 20 },
+    } as any;
+    expect(isOutsideBounds(vs, dynamicData)).toBe(true);
+  });
+});

--- a/taxonium_component/src/hooks/useGetDynamicData.tsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.tsx
@@ -25,6 +25,22 @@ interface DynamicData {
   lastBounds?: Record<string, number>;
 }
 
+export function isOutsideBounds(
+  vs: Record<string, number>,
+  dynamicData: DynamicData | null
+) {
+  return (
+    vs.min_x !== undefined &&
+    dynamicData &&
+    dynamicData.lastBounds &&
+    dynamicData.lastBounds.min_x !== undefined &&
+    (vs.min_x < dynamicData.lastBounds.min_x ||
+      vs.max_x > dynamicData.lastBounds.max_x ||
+      vs.min_y < dynamicData.lastBounds.min_y ||
+      vs.max_y > dynamicData.lastBounds.max_y)
+  );
+}
+
 function useGetDynamicData(
   backend,
   colorBy,
@@ -81,16 +97,7 @@ function useGetDynamicData(
 
   const isCurrentlyOutsideBounds = useMemo(() => {
     const vs = computeBounds({ ...viewState }, deckSize);
-    return (
-      vs.min_x &&
-      dynamicData &&
-      dynamicData.lastBounds &&
-      dynamicData.lastBounds.min_x &&
-      (vs.min_x < dynamicData.lastBounds.min_x ||
-        vs.max_x > dynamicData.lastBounds.max_x ||
-        vs.min_y < dynamicData.lastBounds.min_y ||
-        vs.max_y > dynamicData.lastBounds.max_y)
-    );
+    return isOutsideBounds(vs, dynamicData);
   }, [viewState, dynamicData, deckSize]);
 
   useEffect(() => {

--- a/taxonium_component/vitest.setup.js
+++ b/taxonium_component/vitest.setup.js
@@ -1,0 +1,1 @@
+import './.storybook/vitest.setup.js';


### PR DESCRIPTION
## Summary
- adjust `useGetDynamicData` bounds check to explicitly check `undefined` rather than falsy
- expose helper `isOutsideBounds` and use it inside the hook
- add unit test covering the zero `min_x` case
- hook up Vitest setup for tests

## Testing
- `npx vitest run src/hooks/useGetDynamicData.test.ts --reporter dot`