### PR TITLE
Add global ErrorBoundary to Taxonium component

### DIFF
--- a/taxonium_component/README.md
+++ b/taxonium_component/README.md
@@ -22,6 +22,10 @@ function App() {
 export default App;
 ```
 
+`Taxonium` now includes an internal error boundary. If the component
+encounters an unexpected error it will display a helpful message rather
+than leaving a blank screen.
+
 ## Using script tags
 
 ```html

--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -35,7 +35,7 @@ interface SourceData {
   [key: string]: unknown;
 }
 
-interface TaxoniumProps {
+export interface TaxoniumProps {
   sourceData?: SourceData;
   backendUrl?: string;
   configDict?: Record<string, unknown>;

--- a/taxonium_component/src/components/TaxoniumErrorBoundary.tsx
+++ b/taxonium_component/src/components/TaxoniumErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { toast } from "react-hot-toast";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export default class TaxoniumErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("Taxonium crashed", error, info);
+    toast.error("An unexpected error occurred while rendering the tree.");
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 m-4 border border-red-300 bg-red-50 text-red-800">
+          <h2 className="font-bold">Something went wrong.</h2>
+          <p className="break-words text-sm mt-2">{this.state.error?.message}</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/taxonium_component/src/index.ts
+++ b/taxonium_component/src/index.ts
@@ -1,3 +1,0 @@
-import Taxonium from "./Taxonium";
-
-export default Taxonium;

--- a/taxonium_component/src/index.tsx
+++ b/taxonium_component/src/index.tsx
@@ -1,0 +1,13 @@
+import RawTaxonium, { TaxoniumProps } from "./Taxonium";
+import TaxoniumErrorBoundary from "./components/TaxoniumErrorBoundary";
+
+export { RawTaxonium };
+export type { TaxoniumProps };
+
+export default function Taxonium(props: TaxoniumProps) {
+  return (
+    <TaxoniumErrorBoundary>
+      <RawTaxonium {...props} />
+    </TaxoniumErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `TaxoniumErrorBoundary` component
- export a wrapped default component using the new boundary
- document improved error handling in README

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_683f0db99174832586a5961a82b4d2a0