### PR TITLE
Improve error handling

### DIFF
--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -26,6 +26,7 @@ import { Tooltip as ReactTooltip } from "react-tooltip";
 const ReactTooltipAny: any = ReactTooltip;
 import { Toaster } from "react-hot-toast";
 import type { DeckSize } from "./types/common";
+import GlobalErrorBoundary from "./components/GlobalErrorBoundary";
 
 interface SourceData {
   status: string;
@@ -113,7 +114,11 @@ function Taxonium({
     sourceData ?? null
   );
   if (!backend) {
-    return null;
+    return (
+      <div className="p-4 bg-red-50 text-red-800">
+        Failed to initialise backend.
+      </div>
+    );
   }
   let hoverDetails = useHoverDetails();
   const gisaidHoverDetails = useNodeDetails("gisaid-hovered", backend);
@@ -203,8 +208,9 @@ function Taxonium({
   const treenomeState = useTreenomeState(data, deckRef, view, settings);
 
   return (
-    <div className="w-full h-full flex">
-      <Toaster />
+    <GlobalErrorBoundary>
+      <div className="w-full h-full flex">
+        <Toaster />
       <ReactTooltipAny
         id="global-tooltip"
         delayHide={400}
@@ -289,6 +295,7 @@ function Taxonium({
         </div>
       </div>
     </div>
+    </GlobalErrorBoundary>
   );
 }
 

--- a/taxonium_component/src/components/GlobalErrorBoundary.tsx
+++ b/taxonium_component/src/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { toast } from "react-hot-toast";
+
+interface GlobalErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface GlobalErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export default class GlobalErrorBoundary extends React.Component<
+  GlobalErrorBoundaryProps,
+  GlobalErrorBoundaryState
+> {
+  constructor(props: GlobalErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error): GlobalErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+    toast.error(error.message);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 bg-red-50 text-red-800">
+          <p>An unexpected error occurred.</p>
+          {this.state.error && (
+            <pre className="whitespace-pre-wrap text-sm">
+              {this.state.error.message}
+            </pre>
+          )}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/taxonium_component/src/index.ts
+++ b/taxonium_component/src/index.ts
@@ -1,3 +1,5 @@
 import Taxonium from "./Taxonium";
+import GlobalErrorBoundary from "./components/GlobalErrorBoundary";
 
 export default Taxonium;
+export { GlobalErrorBoundary };


### PR DESCRIPTION
## Summary
- add a global error boundary component
- show a helpful message when backend fails to initialise
- export the new boundary from the library
- wrap the Taxonium component in the global boundary

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_683f0dc029c48325ab2450176689ef04