### PR TITLE
Fix text rendering with 2D zoom

### DIFF
--- a/taxonium_component/src/hooks/useLayers.tsx
+++ b/taxonium_component/src/hooks/useLayers.tsx
@@ -417,8 +417,12 @@ const useLayers = ({
     );
   }
 
+  const zoomY = Array.isArray(viewState.zoom)
+    ? viewState.zoom[1]
+    : (viewState.zoom as number);
+
   const proportionalToNodesOnScreen =
-    (config as any).num_tips / 2 ** (viewState.zoom as number);
+    (config as any).num_tips / 2 ** zoomY;
 
   // If leaves are fewer than max_text_number, add a text layer
   if (


### PR DESCRIPTION
## Summary
- update node text visibility calculation to use the vertical zoom value

## Testing
- `npm run check-types` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846e492b37c8325b105080b8cf3e980