### PR TITLE
Fix text rendering with 2D zoom

### DIFF
--- a/taxonium_component/src/hooks/useLayers.tsx
+++ b/taxonium_component/src/hooks/useLayers.tsx
@@ -380,6 +380,11 @@ const useLayers = ({
       lineWidthScale: 2,
     };
 
+    const zoomY = Array.isArray(viewState.zoom)
+      ? viewState.zoom[1]
+      : (viewState.zoom as number);
+    const textSizeForZoom = Math.max(8, Math.min(24, 11 * Math.pow(2, zoomY)));
+
     const clade_label_layer = {
       layerType: "TextLayer",
       id: "main-clade-node",
@@ -396,7 +401,7 @@ const useLayers = ({
       billboard: true,
       getTextAnchor: "end",
       getAlignmentBaseline: "center",
-      getSize: 11,
+      getSize: textSizeForZoom,
       modelMatrix: modelMatrix,
       updateTriggers: {
         getPosition: [getX],
@@ -418,7 +423,7 @@ const useLayers = ({
   }
 
   const proportionalToNodesOnScreen =
-    (config as any).num_tips / 2 ** (viewState.zoom as number);
+    (config as any).num_tips / 2 ** zoomY;
 
   // If leaves are fewer than max_text_number, add a text layer
   if (
@@ -445,7 +450,14 @@ const useLayers = ({
       billboard: true,
       getTextAnchor: "start",
       getAlignmentBaseline: "center",
-      getSize: data.data.nodes.length < 200 ? 12 : 9.5,
+      getSize:
+        Math.max(
+          8,
+          Math.min(
+            24,
+            (data.data.nodes.length < 200 ? 12 : 9.5) * Math.pow(2, zoomY)
+          )
+        ),
       modelMatrix: modelMatrix,
       getPixelOffset: [10, 0],
     };

--- a/taxonium_component/src/hooks/useSearch.tsx
+++ b/taxonium_component/src/hooks/useSearch.tsx
@@ -322,7 +322,7 @@ const useSearch = ({
         ...view.viewState,
         real_target: undefined,
         target: new_target,
-        zoom: newZoom,
+        zoom: [view.viewState.zoom[0], newZoom],
       };
       console.log(
         "zoom to search new VS",


### PR DESCRIPTION
## Summary
- update clade and node label sizes based on vertical zoom
- ensure search zoom uses two dimensional zoom state

## Testing
- `npm run check-types` *(fails: Cannot find module 'react-dom/client' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846e492b37c8325b105080b8cf3e980