### PR TITLE
Add metadata filtering and align JS output

### DIFF
--- a/taxoniumtools/benchmarks/benchmark_usher_to_taxonium.py
+++ b/taxoniumtools/benchmarks/benchmark_usher_to_taxonium.py
@@ -1,0 +1,33 @@
+import time
+from pathlib import Path
+
+from taxoniumtools import usher_to_taxonium
+
+
+def benchmark_basic():
+    """Benchmark usher_to_taxonium on the provided test dataset."""
+    data_dir = Path(__file__).resolve().parent.parent / "test_data"
+    input_file = data_dir / "tfci.pb"
+    metadata_file = data_dir / "tfci.meta.tsv.gz"
+    genbank_file = data_dir / "hu1.gb"
+    out_file = Path("/tmp/taxonium_test.jsonl.gz")
+
+    start = time.perf_counter()
+    usher_to_taxonium.do_processing(
+        str(input_file),
+        str(out_file),
+        metadata_file=str(metadata_file),
+        genbank_file=str(genbank_file),
+        columns="genbank_accession,country,date,pangolin_lineage",
+        clade_types="nextstrain,pango",
+    )
+    return time.perf_counter() - start
+
+
+def main():
+    runtime = benchmark_basic()
+    print(f"Runtime: {runtime:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/taxoniumtools/node/README.md
+++ b/taxoniumtools/node/README.md
@@ -1,0 +1,21 @@
+# Node.js usher_to_taxonium
+
+This script converts a UShER protobuf (`.pb`) file to the Taxonium
+`jsonl` format. It decodes the protobuf using `protobufjs`, parses the
+Newick string with `jstree.js`, and writes out the node table in the
+same structure as the Python pipeline.
+
+Install dependencies once with:
+
+```
+npm install
+```
+
+Run with:
+
+```
+node usher_to_taxonium.js <input.pb> <metadata.tsv.gz> <genbank.gb> <output.jsonl.gz> [clade_types] [columns]
+```
+where `clade_types` is an optional comma-separated list like `nextstrain,pango`.
+`columns` optionally limits which metadata columns are stored (comma separated,
+matching the Python script's `--columns` flag).

--- a/taxoniumtools/node/jstree.js
+++ b/taxoniumtools/node/jstree.js
@@ -1,0 +1,602 @@
+/* eslint-disable */
+
+// This file is heavily based on JStree with some small edits made for fixes in the Taxonium context
+// see https://github.com/lh3/jstreeview
+
+/* The MIT License
+
+   Copyright (c) 2008 Genome Research Ltd (GRL).
+                 2010 Broad Institute
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+// Author: Heng Li <lh3@sanger.ac.uk>
+
+/*
+  A phylogenetic tree is parsed into the following Java-like structure:
+
+  class Node {
+	Node parent;  // pointer to the parent node; null if root
+	Node[] child; // array of pointers to child nodes
+	String name;  // name of the current node
+	double d;     // distance to the parent node
+	bool hl;      // if the node needs to be highlighted
+	bool hidden;  // if the node and all its desendants are collapsed
+  };
+
+  class Tree {
+	Node[] node;  // list of nodes in the finishing order (the leftmost leaf is the first and the root the last)
+	int error;    // errors in parsing: 0x1=missing left parenthesis; 0x2=missing right; 0x4=unpaired brackets
+	int n_tips;   // number of tips/leaves in the tree
+  };
+
+  The minimal code for plotting/editing a tree in the Newick format is:
+
+<head><!--[if IE]><script src="excanvas.js"></script><![endif]-->
+<script language="JavaScript" src="knhx.js"></script></head>
+<body onLoad="knhx_init('canvas', 'nhx');">
+<textarea id="nhx" rows="20" cols="120" style="font:11px monospace"></textarea>
+<canvas id="canvas" width="800" height="100" style="border:1px solid"></canvas>
+</body>
+
+*/
+
+/********************************************
+ ****** The New Hampshire format parser *****
+ ********************************************/
+
+function kn_new_node() {
+  // private method
+  return {
+    parent: null,
+    child: [],
+    name: "",
+    meta: "",
+    d: -1.0,
+    hl: false,
+    hidden: false,
+  };
+}
+
+function kn_add_node(str, l, tree, x) {
+  // private method
+  let i;
+  var r,
+    beg,
+    end = 0,
+    z;
+  z = kn_new_node();
+  for (
+    i = l, beg = l;
+    i < str.length && str.charAt(i) != "," && str.charAt(i) != ")";
+    ++i
+  ) {
+    var c = str.charAt(i);
+    if (c == "[") {
+      var meta_beg = i;
+      if (end == 0) end = i;
+      do ++i;
+      while (i < str.length && str.charAt(i) != "]");
+      if (i == str.length) {
+        tree.error |= 4;
+        break;
+      }
+      z.meta = str.substr(meta_beg, i - meta_beg + 1);
+    } else if (c == ":") {
+      if (end == 0) end = i;
+      for (var j = ++i; i < str.length; ++i) {
+        var cc = str.charAt(i);
+        if (
+          (cc < "0" || cc > "9") &&
+          cc != "e" &&
+          cc != "E" &&
+          cc != "+" &&
+          cc != "-" &&
+          cc != "."
+        )
+          break;
+      }
+      z.d = parseFloat(str.substr(j, i - j));
+      --i;
+    } else if (c < "!" && c > "~" && end == 0) end = i;
+  }
+  if (end == 0) end = i;
+  if (end > beg) z.name = str.substr(beg, end - beg);
+  tree.node.push(z);
+  return i;
+}
+
+/* Parse a string in the New Hampshire format and return a pointer to the tree. */
+function kn_parse(str) {
+  var stack = new Array();
+  var tree = new Object();
+  tree.error = tree.n_tips = 0;
+  tree.node = new Array();
+  for (var l = 0; l < str.length; ) {
+    while (l < str.length && (str.charAt(l) < "!" || str.charAt(l) > "~")) ++l;
+    if (l == str.length) break;
+    var c = str.charAt(l);
+    if (c == ",") ++l;
+    else if (c == "(") {
+      stack.push(-1);
+      ++l;
+    } else if (c == ")") {
+      let x, m, i;
+      x = tree.node.length;
+      for (i = stack.length - 1; i >= 0; --i) if (stack[i] < 0) break;
+      if (i < 0) {
+        tree.error |= 1;
+        break;
+      }
+      m = stack.length - 1 - i;
+      l = kn_add_node(str, l + 1, tree, m);
+      for (i = stack.length - 1, m = m - 1; m >= 0; --m, --i) {
+        tree.node[x].child[m] = tree.node[stack[i]];
+        tree.node[stack[i]].parent = tree.node[x];
+      }
+      stack.length = i;
+      stack.push(x);
+    } else {
+      ++tree.n_tips;
+      stack.push(tree.node.length);
+      l = kn_add_node(str, l, tree, 0);
+    }
+  }
+  if (stack.length > 1) tree.error |= 2;
+  tree.root = tree.node[tree.node.length - 1];
+  return tree;
+}
+
+/*********************************
+ ***** Output a tree in text *****
+ *********************************/
+
+/* convert a tree to the New Hampshire string */
+function kn_write_nh(tree) {
+  // calculate the depth of each node
+  tree.node[tree.node.length - 1].depth = 0;
+  for (var i = tree.node.length - 2; i >= 0; --i) {
+    var p = tree.node[i];
+    p.depth = p.parent.depth + 1;
+  }
+  // generate the string
+  var str = "";
+  var cur_depth = 0,
+    is_first = 1;
+  for (var i = 0; i < tree.node.length; ++i) {
+    var p = tree.node[i];
+    var n_bra = p.depth - cur_depth;
+    if (n_bra > 0) {
+      if (is_first) is_first = 0;
+      else str += ",\n";
+      for (var j = 0; j < n_bra; ++j) str += "(";
+    } else if (n_bra < 0) str += "\n)";
+    else str += ",\n";
+    if (p.name) str += String(p.name);
+    if (p.d >= 0.0) str += ":" + p.d;
+    if (p.meta) str += p.meta;
+    cur_depth = p.depth;
+  }
+  str += "\n";
+  return str;
+}
+
+/* print the tree topology (for debugging only) */
+function kn_check_tree(tree) {
+  document.write("<table border=1><tr><th>name<th>id<th>dist<th>x<th>y</tr>");
+  for (var i = 0; i < tree.node.length; ++i) {
+    var p = tree.node[i];
+    document.write(
+      "<tr>" +
+        "<td>" +
+        p.name +
+        "<td>" +
+        i +
+        "<td>" +
+        p.d +
+        "<td>" +
+        p.x +
+        "<td>" +
+        p.y +
+        "</tr>"
+    );
+  }
+  document.write("</table>");
+}
+
+/**********************************************
+ ****** Functions for manipulating a tree *****
+ **********************************************/
+
+/* Expand the tree into an array in the finishing order */
+function kn_expand_node(root) {
+  var node, stack;
+  node = new Array();
+  stack = new Array();
+  stack.push({ p: root, i: 0 });
+  for (;;) {
+    while (
+      stack[stack.length - 1].i != stack[stack.length - 1].p.child.length &&
+      !stack[stack.length - 1].p.hidden
+    ) {
+      var q = stack[stack.length - 1];
+      stack.push({ p: q.p.child[q.i], i: 0 });
+    }
+    node.push(stack.pop().p);
+    if (stack.length > 0) ++stack[stack.length - 1].i;
+    else break;
+  }
+  return node;
+}
+
+/* Count the number of leaves */
+function kn_count_tips(tree) {
+  tree.n_tips = 0;
+  for (var i = 0; i < tree.node.length; ++i)
+    if (tree.node[i].child.length == 0 || tree.node[i].hidden) ++tree.n_tips;
+  return tree.n_tips;
+}
+
+/* Highlight: set node.hl for leaves matching "pattern" */
+function kn_search_leaf(tree, pattern) {
+  var re = null;
+  if (pattern != null && pattern != "") {
+    re = new RegExp(pattern, "i");
+    if (re == null) alert("Wrong regular expression: '" + pattern + "'");
+  }
+  for (var i = 0; i < tree.node.length; ++i) {
+    var p = tree.node[i];
+    if (p.child.length == 0)
+      p.hl = re != null && re.test(p.name) ? true : false;
+  }
+}
+
+/* Remove: delete a node and all its descendants */
+function kn_remove_node(tree, node) {
+  var root = tree.node[tree.node.length - 1];
+  if (node == root) return;
+
+  var z = kn_new_node();
+  z.child.push(root);
+  root.parent = z;
+
+  var p = node.parent,
+    i;
+  if (p.child.length == 2) {
+    // then p will be removed
+    var q,
+      r = p.parent;
+    i = p.child[0] == node ? 0 : 1;
+    q = p.child[1 - i]; // the other child
+    q.d += p.d;
+    q.parent = r;
+    for (let i = 0; i < r.child.length; ++i) if (r.child[i] == p) break;
+    r.child[i] = q;
+    p.parent = null;
+  } else {
+    var j, k;
+    for (let i = 0; i < p.child.length; ++i) if (p.child[i] == node) break;
+    for (j = k = 0; j < p.child.length; ++j) {
+      p.node[k] = p.node[j];
+      if (j != i) ++k;
+    }
+    --p.child.length;
+  }
+
+  root = z.child[0];
+  root.parent = null;
+  return root;
+}
+
+/* Move: prune the subtree descending from p and regragh it to the edge between q and its parent */
+function kn_move_node(tree, p, q) {
+  var root = tree.node[tree.node.length - 1];
+  if (p == root) return null; // p cannot be root
+  for (var r = q; r.parent; r = r.parent) if (r == p) return null; // p is an ancestor of q. We cannot move in this case.
+
+  root = kn_remove_node(tree, p);
+
+  var z = kn_new_node(); // a fake root
+  z.child.push(root);
+  root.parent = z;
+
+  var i,
+    r = q.parent;
+  for (let i = 0; i < r.child.length; ++i) if (r.child[i] == q) break;
+  var s = kn_new_node(); // a new node
+  s.parent = r;
+  r.child[i] = s;
+  if (q.d >= 0.0) {
+    s.d = q.d / 2.0;
+    q.d /= 2.0;
+  }
+  s.child.push(p);
+  p.parent = s;
+  s.child.push(q);
+  q.parent = s;
+
+  root = z.child[0];
+  root.parent = null;
+  return root;
+}
+
+/* Reroot: put the root in the middle of node and its parent */
+function kn_reroot(root, node, dist) {
+  var i, d, tmp;
+  var p, q, r, s, new_root;
+  if (node == root) return root;
+  if (dist < 0.0 || dist > node.d) dist = node.d / 2.0;
+  tmp = node.d;
+
+  /* p: the central multi-parent node
+   * q: the new parent, previous a child of p
+   * r: old parent
+   * i: previous position of q in p
+   * d: previous distance p->d
+   */
+  q = new_root = kn_new_node();
+  q.child[0] = node;
+  q.child[0].d = dist;
+  p = node.parent;
+  q.child[0].parent = q;
+  for (let i = 0; i < p.child.length; ++i) if (p.child[i] == node) break;
+  q.child[1] = p;
+  d = p.d;
+  p.d = tmp - dist;
+  r = p.parent;
+  p.parent = q;
+  while (r != null) {
+    s = r.parent; /* store r's parent */
+    p.child[i] = r; /* change r to p's child */
+    for (let i = 0; i < r.child.length; ++i /* update i */)
+      if (r.child[i] == p) break;
+    r.parent = p; /* update r's parent */
+    tmp = r.d;
+    r.d = d;
+    d = tmp; /* swap r->d and d, i.e. update r->d */
+    q = p;
+    p = r;
+    r = s; /* update p, q and r */
+  }
+  /* now p is the root node */
+  if (p.child.length == 2) {
+    /* remove p and link the other child of p to q */
+    r = p.child[1 - i]; /* get the other child */
+    for (let i = 0; i < q.child.length; ++i /* the position of p in q */)
+      if (q.child[i] == p) break;
+    r.d += p.d;
+    r.parent = q;
+    q.child[i] = r; /* link r to q */
+  } else {
+    /* remove one child in p */
+    for (j = k = 0; j < p.child.length; ++j) {
+      p.child[k] = p.child[j];
+      if (j != i) ++k;
+    }
+    --p.child.length;
+  }
+  return new_root;
+}
+
+function kn_multifurcate(p) {
+  var i, par, idx, tmp, old_length;
+  if (p.child.length == 0 || !p.parent) return;
+  par = p.parent;
+  for (let i = 0; i < par.child.length; ++i) if (par.child[i] == p) break;
+  idx = i;
+  tmp = par.child.length - idx - 1;
+  old_length = par.child.length;
+  par.child.length += p.child.length - 1;
+  for (let i = 0; i < tmp; ++i)
+    par.child[par.child.length - 1 - i] = par.child[old_length - 1 - i];
+  for (let i = 0; i < p.child.length; ++i) {
+    p.child[i].parent = par;
+    if (p.child[i].d >= 0 && p.d >= 0) p.child[i].d += p.d;
+    par.child[i + idx] = p.child[i];
+  }
+}
+
+function kn_reorder(root) {
+  const sort_leaf = function (a, b) {
+    if (a.depth < b.depth) return 1;
+    if (a.depth > b.depth) return -1;
+    return String(a.name) < String(b.name)
+      ? -1
+      : String(a.name) > String(b.name)
+      ? 1
+      : 0;
+  };
+  const sort_weight = function (a, b) {
+    return a.weight / a.n_tips - b.weight / b.n_tips;
+  };
+
+  var x = new Array();
+  var i,
+    node = kn_expand_node(root);
+  // get depth
+  node[node.length - 1].depth = 0;
+  for (let i = node.length - 2; i >= 0; --i) {
+    var q = node[i];
+    q.depth = q.parent.depth + 1;
+    if (q.child.length == 0) x.push(q);
+  }
+  // set weight for leaves
+  x.sort(sort_leaf);
+  for (let i = 0; i < x.length; ++i) (x[i].weight = i), (x[i].n_tips = 1);
+  // set weight for internal nodes
+  for (let i = 0; i < node.length; ++i) {
+    var q = node[i];
+    if (q.child.length) {
+      // internal
+      var j,
+        n = 0,
+        w = 0;
+      for (j = 0; j < q.child.length; ++j) {
+        n += q.child[j].n_tips;
+        w += q.child[j].weight;
+      }
+      q.n_tips = n;
+      q.weight = w;
+    }
+  }
+  // swap children
+  for (let i = 0; i < node.length; ++i)
+    if (node[i].child.length >= 2) node[i].child.sort(sort_weight);
+}
+
+function kn_reorder_num_tips(root) {
+  const sort_leaf = function (a, b) {
+    return a.num_tips - b.num_tips;
+  };
+
+  const sort_weight = function (a, b) {
+    return a.num_tips - b.num_tips;
+  };
+
+  var x = new Array();
+  var i,
+    node = kn_expand_node(root);
+  // get depth
+  node[node.length - 1].depth = 0;
+  for (let i = node.length - 2; i >= 0; --i) {
+    var q = node[i];
+    q.depth = q.parent.depth + 1;
+    if (q.child.length == 0) x.push(q);
+  }
+  // set weight for leaves
+  x.sort(sort_leaf);
+  for (let i = 0; i < x.length; ++i) (x[i].weight = i), (x[i].n_tips = 1);
+  // set weight for internal nodes
+  for (let i = 0; i < node.length; ++i) {
+    var q = node[i];
+    if (q.child.length) {
+      // internal
+      var j,
+        n = 0,
+        w = 0;
+      for (j = 0; j < q.child.length; ++j) {
+        n += q.child[j].n_tips;
+        w += q.child[j].weight;
+      }
+      q.n_tips = n;
+      q.weight = w;
+    }
+  }
+  // swap children
+  for (let i = 0; i < node.length; ++i)
+    if (node[i].child.length >= 2) node[i].child.sort(sort_weight);
+}
+
+/*****************************************
+ ***** Functions for plotting a tree *****
+ *****************************************/
+
+/* Calculate the coordinate of each node */
+function kn_calxy(tree, is_real) {
+  var i, j, scale;
+  // calculate y
+  scale = tree.n_tips - 1;
+  for (let i = (j = 0); i < tree.node.length; ++i) {
+    var p = tree.node[i];
+    p.y =
+      p.child.length && !p.hidden
+        ? (p.child[0].y + p.child[p.child.length - 1].y) / 2.0
+        : j++ / scale;
+    if (p.child.length == 0) p.miny = p.maxy = p.y;
+    else
+      (p.miny = p.child[0].miny), (p.maxy = p.child[p.child.length - 1].maxy);
+  }
+  // calculate x
+  if (is_real) {
+    // use branch length
+    var root = tree.node[tree.node.length - 1];
+    scale = root.x = root.d >= 0.0 ? root.d : 0.0;
+    for (let i = tree.node.length - 2; i >= 0; --i) {
+      var p = tree.node[i];
+      p.x = p.parent.x + (p.d >= 0.0 ? p.d : 0.0);
+      if (p.x > scale) scale = p.x;
+    }
+    if (scale == 0.0) is_real = false;
+  }
+  if (!is_real) {
+    // no branch length
+    scale = tree.node[tree.node.length - 1].x = 1.0;
+    for (let i = tree.node.length - 2; i >= 0; --i) {
+      var p = tree.node[i];
+      p.x = p.parent.x + 1.0;
+      if (p.x > scale) scale = p.x;
+    }
+    for (let i = 0; i < tree.node.length - 1; ++i)
+      if (tree.node[i].child.length == 0) tree.node[i].x = scale;
+  }
+  // rescale x
+  for (let i = 0; i < tree.node.length; ++i) tree.node[i].x /= scale;
+  return is_real;
+}
+
+function kn_get_node(tree, conf, x, y) {
+  if (conf.is_circular) {
+    for (var i = 0; i < tree.node.length; ++i) {
+      var p = tree.node[i];
+      var tmp_x = Math.floor(
+        conf.width / 2 +
+          p.x * conf.real_r * Math.cos(p.y * conf.full_arc) +
+          0.999
+      );
+      var tmp_y = Math.floor(
+        conf.height / 2 +
+          p.x * conf.real_r * Math.sin(p.y * conf.full_arc) +
+          0.999
+      );
+      var tmp_l = 2;
+      if (
+        x >= tmp_x - tmp_l &&
+        x <= tmp_x + tmp_l &&
+        y >= tmp_y - tmp_l &&
+        y <= tmp_y + tmp_l
+      )
+        return i;
+    }
+  } else {
+    for (var i = 0; i < tree.node.length; ++i) {
+      var tmp_x = tree.node[i].x * conf.real_x + conf.shift_x;
+      var tmp_y = tree.node[i].y * conf.real_y + conf.shift_y;
+      var tmp_l = conf.box_width * 0.6;
+      if (
+        x >= tmp_x - tmp_l &&
+        x <= tmp_x + tmp_l &&
+        y >= tmp_y - tmp_l &&
+        y <= tmp_y + tmp_l
+      )
+        return i;
+    }
+  }
+  return tree.node.length;
+}
+
+module.exports = {
+  kn_expand_node,
+  kn_reorder,
+  kn_parse,
+  kn_calxy,
+  kn_reorder_num_tips,
+};

--- a/taxoniumtools/node/package-lock.json
+++ b/taxoniumtools/node/package-lock.json
@@ -1,0 +1,132 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "biojs-io-genbank": "^0.1.2",
+        "protobufjs": "^7.5.3"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/biojs-io-genbank": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/biojs-io-genbank/-/biojs-io-genbank-0.1.2.tgz",
+      "integrity": "sha512-WwuEAq81vt2x6rlqTt1dVW/CxWPvwjT30LF4S3gn4jSv++qh4TrO54UoGmuPHv8ON5Bc7NPBjq8n7N+8xszW4w==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
+      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/taxoniumtools/node/package.json
+++ b/taxoniumtools/node/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "description": "",
+  "main": "usher_to_taxonium.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "biojs-io-genbank": "^0.1.2",
+    "protobufjs": "^7.5.3"
+  }
+}

--- a/taxoniumtools/node/parsimony.proto
+++ b/taxoniumtools/node/parsimony.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";                                                                                                                                                                                              
+package Parsimony;
+
+message mut {
+    int32 position = 1; // Position in the chromosome
+    /* All nucleotides are encoded as integers (0:A, 1:C, 2:G, 3:T) */
+    int32 ref_nuc = 2; // Reference nucleotide at this position
+    int32 par_nuc = 3; // Nucleotide of parent at this position
+    repeated int32 mut_nuc = 4; // Mutated nucleotide in this node at this position
+    string chromosome = 5; // Chromosome string. Currently unused.
+}
+
+message mutation_list {
+    repeated mut mutation = 1;
+}
+
+message condensed_node {
+    string node_name = 1; // The node name as given in the newick tree
+    repeated string condensed_leaves = 2; // A list of strings for the names of identical sequences all of which are represented by the node above
+}
+
+message node_metadata {
+    repeated string clade_annotations = 1;
+}
+
+message data {
+    string newick = 1; // Newick tree string. May contain distances, but note that these may be distinct from distances as calculated with UShER
+    repeated mutation_list node_mutations = 2; // Mutations_list object for each node of this tree, in the order that nodes are encountered in a preorder traversal of the tree in the newick string
+    repeated condensed_node condensed_nodes = 3; // A dictionary-like object mapping names in the newick tree to a larger set of identical nodes that have been collapsed into this single node
+    repeated node_metadata metadata = 4; // Clade annotations on a per-node basis, in the order that nodes are encountered in a preorder traversal of the tree
+}

--- a/taxoniumtools/node/usher_to_taxonium.js
+++ b/taxoniumtools/node/usher_to_taxonium.js
@@ -1,0 +1,382 @@
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const protobuf = require('protobufjs');
+const { kn_parse } = require('./jstree');
+
+// simple parser for GenBank file returning sequence and CDS gene coordinates
+function parseGenbank(gbPath) {
+  if (!gbPath) return null;
+  const text = fs.readFileSync(gbPath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const genes = {};
+  let seq = '';
+  let inOrigin = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('ORIGIN')) { inOrigin = true; continue; }
+    if (inOrigin) {
+      if (line.startsWith('//')) break;
+      seq += line.replace(/\s|\d/g, '');
+      continue;
+    }
+    const m = line.match(/^\s+CDS\s+(\d+)\.\.(\d+)/);
+    if (m) {
+      const start = parseInt(m[1]) - 1; // convert to 0-indexed start
+      const end = parseInt(m[2]);       // end already points to the next base
+      let j = i + 1;
+      let gene = '';
+      while (j < lines.length && lines[j].startsWith('                     ')) {
+        const g = lines[j].match(/\/gene="([^"]+)"/);
+        if (g) { gene = g[1]; break; }
+        j++;
+      }
+      if (gene) genes[gene] = { name: gene, strand: 1, start, end };
+    }
+  }
+  return { seq: seq.toUpperCase(), genes };
+}
+
+function newNode() {
+  return { parent:null, child:[], name:'', meta:'', d:-1.0, hl:false, hidden:false };
+}
+
+function loadMetadata(metaPath, columns) {
+  if (!metaPath) return [{}, []];
+  let data;
+  if (metaPath.endsWith('.gz')) {
+    const buf = fs.readFileSync(metaPath);
+    data = zlib.gunzipSync(buf).toString();
+  } else {
+    data = fs.readFileSync(metaPath, 'utf8');
+  }
+  const lines = data.trim().split(/\r?\n/);
+  const headers = lines[0].split(/\t|,/);
+  const out = {};
+  const keep = [];
+  const colSet = columns ? new Set(columns.split(',')) : null;
+  for (let j = 1; j < headers.length; j++) {
+    if (!colSet || colSet.has(headers[j])) keep.push(j);
+  }
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i]) continue;
+    const parts = lines[i].split(/\t|,/);
+    const key = parts[0];
+    const obj = {};
+    keep.forEach(j => { obj['meta_' + headers[j]] = parts[j] || ''; });
+    out[key] = obj;
+  }
+  return [out, keep.map(j => 'meta_' + headers[j])];
+}
+
+function assignNumTips(node) {
+  if (node.child.length === 0) {
+    node.num_tips = 1;
+  } else {
+    node.num_tips = 0;
+    node.child.forEach(c => {
+      node.num_tips += assignNumTips(c);
+    });
+  }
+  return node.num_tips;
+}
+
+function expandCondensedNodes(root, condensed) {
+  const nameToNode = new Map();
+  preorder(root).forEach(n => { if(n.name) nameToNode.set(n.name, n); });
+  condensed.forEach(cn => {
+    const node = nameToNode.get(cn.nodeName);
+    if(!node) return;
+    const parent = node.parent;
+    cn.condensedLeaves.forEach(lbl => {
+      const n = newNode();
+      n.name = lbl;
+      n.parent = parent;
+      n.child = [];
+      n.edge_length = node.edge_length;
+      n.mut_idx = node.mut_idx ? node.mut_idx.slice() : [];
+      n.aa_idx = node.aa_idx ? node.aa_idx.slice() : [];
+      if(parent) parent.child.push(n);
+    });
+    if(parent) parent.child = parent.child.filter(x => x !== node);
+  });
+}
+
+function setXCoords(root) {
+  function walk(n) {
+    n.child.forEach(c => {
+      c.x_dist = (n.x_dist || 0) + (c.edge_length || 0);
+      walk(c);
+    });
+  }
+  root.x_dist = 0;
+  walk(root);
+  const vals = [];
+  const collect = n => { vals.push(n.x_dist); n.child.forEach(collect); };
+  collect(root);
+  vals.sort((a,b)=>a-b);
+  const pct95 = vals[Math.floor(vals.length * 0.95)] || 1;
+  const scale = 600 / pct95;
+  const scaleNode = n => { n.x_dist = Math.round(n.x_dist * scale * 1e5) / 1e5; n.child.forEach(scaleNode); };
+  scaleNode(root);
+}
+
+function setTerminalYCoords(root) {
+  let i = 0;
+  const leaves = [];
+  const collect = n => { if (n.child.length === 0) leaves.push(n); else n.child.forEach(collect); };
+  collect(root);
+  leaves.forEach(n => { n.y = i++; });
+}
+
+function setInternalYCoords(root) {
+  function post(n) {
+    if (n.child.length > 0) {
+      n.child.forEach(post);
+      const ys = n.child.map(c => c.y);
+      n.y = (Math.min(...ys) + Math.max(...ys)) / 2;
+    }
+  }
+  post(root);
+}
+
+const NUC = ['A','C','G','T'];
+const NUC_WITH_X = ['A','C','G','T','X'];
+const CODON_TABLE = {
+  TTT:'F',TTC:'F',TTA:'L',TTG:'L',TCT:'S',TCC:'S',TCA:'S',TCG:'S',
+  TAT:'Y',TAC:'Y',TAA:'*',TAG:'*',TGT:'C',TGC:'C',TGA:'*',TGG:'W',
+  CTT:'L',CTC:'L',CTA:'L',CTG:'L',CCT:'P',CCC:'P',CCA:'P',CCG:'P',
+  CAT:'H',CAC:'H',CAA:'Q',CAG:'Q',CGT:'R',CGC:'R',CGA:'R',CGG:'R',
+  ATT:'I',ATC:'I',ATA:'I',ATG:'M',ACT:'T',ACC:'T',ACA:'T',ACG:'T',
+  AAT:'N',AAC:'N',AAA:'K',AAG:'K',AGT:'S',AGC:'S',AGA:'R',AGG:'R',
+  GTT:'V',GTC:'V',GTA:'V',GTG:'V',GCT:'A',GCC:'A',GCA:'A',GCG:'A',
+  GAT:'D',GAC:'D',GAA:'E',GAG:'E',GGT:'G',GGC:'G',GGA:'G',GGG:'G'
+};
+
+function complement(seq) {
+  const comp = {A:'T',T:'A',C:'G',G:'C'};
+  return seq.split('').reverse().map(c=>comp[c]||c).join('');
+}
+
+function buildNucToCodon(genes) {
+  const map = new Map();
+  for (const g of Object.values(genes)) {
+    let codon = 0;
+    for (let pos = g.start; pos < g.end; pos += 3) {
+      const obj = { gene: g.name, codon_number: codon, positions: {0:pos,1:pos+1,2:pos+2}, strand: g.strand };
+      for (let k = 0; k < 3; k++) {
+        if(!map.has(pos+k)) map.set(pos+k, []);
+        map.get(pos+k).push(obj);
+      }
+      codon++;
+    }
+  }
+  return map;
+}
+
+function getAAMutations(past, newMuts, seq, nucMap, all, index, recordAll=false) {
+  const out = [];
+  const byCodon = new Map();
+  newMuts.forEach(m => {
+    const codons = nucMap.get(m.position - 1);
+    if (codons) {
+      codons.forEach(codon => {
+        if (!byCodon.has(codon)) byCodon.set(codon, []);
+        byCodon.get(codon).push(m);
+      });
+    }
+  });
+  const flip = {'A':0,'C':1,'G':2,'T':3};
+  for (const [codon, muts] of byCodon.entries()) {
+    const posArr = [seq[codon.positions[0]], seq[codon.positions[1]], seq[codon.positions[2]]];
+    for (const [pos,val] of Object.entries(codon.positions)) {
+      const p = parseInt(val);
+      if (p in past) posArr[pos] = NUC[past[p]];
+    }
+    const finalArr = posArr.slice();
+    const flipped = {};
+    for (const [k,v] of Object.entries(codon.positions)) flipped[v] = parseInt(k);
+    muts.forEach(m => { finalArr[flipped[m.position - 1]] = NUC[m.mut]; });
+    let initial = posArr.join('');
+    let fin = finalArr.join('');
+    if (codon.strand === -1) {
+      initial = complement(initial);
+      fin = complement(fin);
+    }
+    const ia = CODON_TABLE[initial] || 'X';
+    const fa = CODON_TABLE[fin] || 'X';
+    if (ia !== fa || recordAll) {
+      const key = codon.gene + '|' + (codon.codon_number + 1) + '|' + ia + '|' + fa;
+      let id = index.get(key);
+      if (id === undefined) {
+        id = all.length;
+        index.set(key,id);
+        all.push({gene:codon.gene,previous_residue:ia,residue_pos:codon.codon_number+1,new_residue:fa,mutation_id:id,nuc_for_codon:codon.positions[1],type:'aa'});
+      }
+      out.push(id);
+    }
+  }
+  newMuts.forEach(m => { past[m.position - 1] = m.mut; });
+  return out;
+}
+
+function collectMutations(nodeMutations) {
+  const all = [];
+  const index = new Map();
+  const perNode = [];
+  const perNodeObjs = [];
+  nodeMutations.forEach(list => {
+    const idxs = [];
+    const objs = [];
+    if(list && list.mutation) {
+      list.mutation.forEach(m => {
+        const par = NUC[m.parNuc];
+        m.mutNuc.forEach(n => {
+          const key = m.position + '|' + par + '|' + NUC[n];
+          let id = index.get(key);
+          if(id === undefined) {
+            id = all.length;
+            index.set(key,id);
+            all.push({gene:'nt',previous_residue:par,residue_pos:m.position,new_residue:NUC[n],mutation_id:id,type:'nt'});
+          }
+          idxs.push(id);
+        });
+        objs.push({position:m.position,par:m.parNuc,mut:m.mutNuc[0]});
+      });
+    }
+    perNode.push(idxs);
+    perNodeObjs.push(objs);
+  });
+  return {all, perNode, perNodeObjs};
+}
+
+function preorder(n, arr=[]) {
+  arr.push(n);
+  n.child.forEach(c => preorder(c, arr));
+  return arr;
+}
+
+async function main() {
+  if (process.argv.length < 6) {
+    console.error('Usage: node usher_to_taxonium.js <input.pb> <metadata.tsv> <genbank.gb> <output.jsonl(.gz)> [clade_types] [columns]');
+    process.exit(1);
+  }
+  const input = process.argv[2];
+  const metadataPath = process.argv[3];
+  const genbankPath = process.argv[4];
+  const outputPath = process.argv[5];
+  const cladeTypes = process.argv[6] ? process.argv[6].split(',') : [];
+  const columns = process.argv[7] || null;
+
+  const protoPath = path.join(__dirname, 'parsimony.proto');
+  const root = await protobuf.load(protoPath);
+  const Data = root.lookupType('Parsimony.data');
+
+  const buffer = fs.readFileSync(input);
+  const message = Data.decode(buffer);
+
+  const tree = kn_parse(message.newick.replace(/\n/g,'').replace(/;\s*$/,''));
+  const preorderNodes = preorder(tree.root);
+  const idxMap = new Map(preorderNodes.map((n,i)=>[n,i]));
+
+  const {all: allNucMuts, perNode: perNodeNucIdx, perNodeObjs} = collectMutations(message.nodeMutations);
+
+  const gb = parseGenbank(genbankPath);
+  const nucMap = gb ? buildNucToCodon(gb.genes) : null;
+  let rootSeq = gb ? gb.seq.split('') : [];
+  const allAa = [];
+  const aaIndex = new Map();
+  const perNodeAa = new Array(preorderNodes.length).fill(null).map(()=>[]);
+  if (gb) {
+    const past = {};
+    // reconstruct root sequence
+    function post(n){
+      n.child.forEach(post);
+      if(n!==tree.root){
+        perNodeObjs[idxMap.get(n)].forEach(m=>{ past[m.position-1]=m.par; });
+      }
+    }
+    post(tree.root);
+    for(const [pos,val] of Object.entries(past)) rootSeq[pos]=NUC[val];
+
+    const rootMuts = [];
+    for(let i=0;i<rootSeq.length;i++) {
+      const id = allNucMuts.length;
+      allNucMuts.push({gene:'nt',previous_residue:'X',residue_pos:i+1,new_residue:rootSeq[i],mutation_id:id,type:'nt'});
+      perNodeNucIdx[idxMap.get(tree.root)].push(id);
+      rootMuts.push({position:i+1,par:4,mut:NUC.indexOf(rootSeq[i])});
+    }
+    const rootAA = getAAMutations({}, rootMuts, rootSeq, nucMap, allAa, aaIndex, true);
+    tree.root.aa_idx = rootAA;
+  }
+  if (gb) {
+    function walk(node,pastDict){
+      const here = {...pastDict};
+      const muts = perNodeObjs[idxMap.get(node)];
+      const aa = getAAMutations(here,muts,rootSeq,nucMap,allAa,aaIndex);
+      perNodeAa[idxMap.get(node)] = aa;
+      node.aa_idx = aa;
+      node.child.forEach(c=>walk(c,here));
+    }
+    walk(tree.root,{});
+  }
+
+  preorderNodes.forEach((node,i) => {
+    node.mut_idx = perNodeNucIdx[i].slice();
+    node.edge_length = node.mut_idx.length;
+    const meta = message.metadata[i];
+    if(meta && cladeTypes.length>0) {
+      node.clades = {};
+      cladeTypes.forEach((t,j)=>{ node.clades[t] = meta.cladeAnnotations[j] || ''; });
+    }
+  });
+
+  expandCondensedNodes(tree.root, message.condensedNodes);
+  assignNumTips(tree.root);
+  setXCoords(tree.root);
+  setTerminalYCoords(tree.root);
+  setInternalYCoords(tree.root);
+
+  const [metadata, metaKeys] = loadMetadata(metadataPath, columns);
+
+  const nodesSorted = preorder(tree.root).sort((a,b)=>a.y-b.y);
+  const nodeToIndex = new Map(nodesSorted.map((n,i)=>[n,i]));
+
+  const config = { num_tips: tree.root.num_tips, date_created: new Date().toISOString().slice(0,10) };
+  if (gb) config.gene_details = gb.genes;
+  const allMuts = allAa.concat(allNucMuts);
+  const offset = allAa.length;
+  const first = { version: 'dev', mutations: allMuts, total_nodes: nodesSorted.length, config };
+
+  const outStream = outputPath.endsWith('.gz') ? zlib.createGzip() : fs.createWriteStream(outputPath);
+  const fileStream = outputPath.endsWith('.gz') ? fs.createWriteStream(outputPath) : null;
+  if(fileStream) outStream.pipe(fileStream);
+  outStream.write(JSON.stringify(first)+'\n');
+
+  nodesSorted.forEach(n => {
+    const obj = {
+      name: n.name || '',
+      x_dist: n.x_dist,
+      y: n.y,
+      mutations: (n.aa_idx||[]).concat(((n.mut_idx)||[]).map(x=>x+offset)),
+      is_tip: n.child.length===0,
+      parent_id: n.parent?nodeToIndex.get(n.parent):nodeToIndex.get(n),
+      node_id: nodeToIndex.get(n),
+      num_tips: n.num_tips
+    };
+    if(n.clades) obj.clades = n.clades;
+    const meta = metadata[n.name];
+    if (meta) Object.assign(obj, meta);
+    else metaKeys.forEach(k => obj[k]='');
+    outStream.write(JSON.stringify(obj)+'\n');
+  });
+
+  outStream.end();
+  if(fileStream) fileStream.on('finish', () => console.log('Wrote', outputPath));
+  else console.log('Wrote', outputPath);
+}
+
+main().catch(err => {
+  console.error('Failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add optional columns argument to the Node converter
- place amino-acid mutations before nucleotide ones
- store nuc_for_codon zero-indexed to match Python
- document the new argument in the README
- fix gene indexing to use 0-based coordinates

## Testing
- `PYTHONPATH=taxoniumtools/src python3 taxoniumtools/benchmarks/benchmark_usher_to_taxonium.py`
- `node usher_to_taxonium.js ../test_data/tfci.pb ../test_data/tfci.meta.tsv.gz ../test_data/hu1.gb /tmp/node_out2.jsonl.gz nextstrain,pango genbank_accession,country,date,pangolin_lineage`

------
https://chatgpt.com/codex/tasks/task_e_6853f37675848325a86362f85ddd0b32