### PR TITLE
Show backend URL in electron

### DIFF
--- a/taxonium_electron2/main.js
+++ b/taxonium_electron2/main.js
@@ -7,6 +7,31 @@ let mainWindow;
 let backendProcess;
 let backendPort;
 
+// Create a small window showing the backend URL
+function showBackendUrlWindow(url) {
+  const infoWindow = new BrowserWindow({
+    width: 500,
+    height: 150,
+    title: 'Backend URL',
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true
+    }
+  });
+
+  const encoded = encodeURIComponent(url);
+  const html = `<!DOCTYPE html>
+    <html>
+      <body style="font-family: sans-serif; padding: 20px;">
+        <p>Backend server running at:</p>
+        <p><a href="${url}">${url}</a></p>
+        <p><a href="https://taxonium.org?backend=${encoded}">taxonium.org?backend=${encoded}</a></p>
+      </body>
+    </html>`;
+
+  infoWindow.loadURL('data:text/html,' + encodeURIComponent(html));
+}
+
 
 // Calculate max memory for backend (3/4 of system memory)
 const totalMemory = os.totalmem();
@@ -99,6 +124,7 @@ function spawnBackend(filePath) {
       const backendUrl = `http://localhost:${backendPort}`;
       console.log('Backend loaded, sending URL:', backendUrl);
       mainWindow.webContents.send('backend-url', backendUrl);
+      showBackendUrlWindow(backendUrl);
     }
   });
 


### PR DESCRIPTION
## Summary
- add helper window that displays the backend server URL
- show this window once the backend signals that loading is complete
- include a link to open the dataset on taxonium.org

## Testing
- `npm run build` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664fa5ab708325860aaa936173a20b