### PR TITLE
Fix Snapcraft build error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,10 @@ jobs:
           chmod +x binaries/node18_arm64mac
         fi
 
+    - name: Install Snapcraft
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo snap install snapcraft --classic
+
     - name: Build React app
       run: npm run build
 


### PR DESCRIPTION
## Summary
- fix linux build by installing Snapcraft before building Electron

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686689f0a5c4832599b1b54342fe4950