### PR TITLE
Fix minimap color updates when editing legend

### DIFF
--- a/taxonium_component/src/hooks/useLayers.tsx
+++ b/taxonium_component/src/hooks/useLayers.tsx
@@ -473,7 +473,7 @@ const useLayers = ({
     radiusUnits: "pixels",
     onHover: (info: HoverInfo<Node>) => setHoverInfo(info),
     updateTriggers: {
-      getFillColor: [base_data, getNodeColorField],
+      getFillColor: [base_data, getNodeColorField, colorHook],
       getPosition: [minimap_scatter_data, xType],
     },
   };


### PR DESCRIPTION
## Summary
- ensure minimap scatter layer rerenders when legend tip colors change

## Testing
- `npm run check-types`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68906da46f2c8325becf62ec2a12362f