### PR TITLE
chore: update polyfills plugin for vite 6

### DIFF
--- a/taxonium_component/package-lock.json
+++ b/taxonium_component/package-lock.json
@@ -59,7 +59,7 @@
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
         "vite-plugin-css-injected-by-js": "^3.5.2",
-        "vite-plugin-node-polyfills": "^0.17.0",
+        "vite-plugin-node-polyfills": "^0.24.0",
         "vitest": "^3.1.3",
         "web-streams-polyfill": "^4.1.0"
       },
@@ -96,6 +96,50 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@arcgis/components-utils": {
+      "version": "4.33.14",
+      "resolved": "https://registry.npmjs.org/@arcgis/components-utils/-/components-utils-4.33.14.tgz",
+      "integrity": "sha512-H45+zcLWuxygtNPSeNilOf0pw1eVUc2kZOpoBqpw5yW2J2mMU+mN0SQn7IMpSX8XhQ1oMQbQYhpnbVdV716pnw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@arcgis/core": {
+      "version": "4.33.12",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.33.12.tgz",
+      "integrity": "sha512-ZHwS714nldC9r+RKIWDRk2PDJ9f6O3hAaulujOY3reZjbo9DZALRv4rjgdedas6U2Q6iGelPV8iHSPTHVgWjNw==",
+      "dev": true,
+      "license": "SEE LICENSE IN copyright.txt",
+      "peer": true,
+      "dependencies": {
+        "@esri/arcgis-html-sanitizer": "~4.1.0",
+        "@esri/calcite-components": "^3.2.1",
+        "@vaadin/grid": "~24.7.6",
+        "@zip.js/zip.js": "~2.7.62",
+        "luxon": "~3.6.1",
+        "marked": "~15.0.12"
+      }
+    },
+    "node_modules/@arcgis/lumina": {
+      "version": "4.33.14",
+      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.33.14.tgz",
+      "integrity": "sha512-a0BhAue4E6UzMhXwfGElVhfUHwYQDcC6lp3ANruJcUpZfbml9IQ2j2973IRIePj6UX9alLw6sQm9tuzn6kQDQg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@arcgis/components-utils": "4.33.14",
+        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit/context": "^1.1.5",
+        "csstype": "^3.1.3",
+        "lit": "^3.3.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1584,6 +1628,70 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@esri/arcgis-html-sanitizer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.1.0.tgz",
+      "integrity": "sha512-einEveDJ/k1180NOp78PB/4Hje9eBy3dyOGLLtLn6bSkizpUfCwuYBIXOA7Y3F/k/BsTQXgKqUVwQ0eiscWMdA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "xss": "1.0.13"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esri/calcite-components": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.2.1.tgz",
+      "integrity": "sha512-NRBW/bhT4sQM5RAZF7W8/VymaOLgIzaR6yTZFI270Ig4NiQ4DRexjdeo/SwDMBlswFtBw5iya+/h+fAur2+Hlg==",
+      "dev": true,
+      "license": "SEE LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@arcgis/components-utils": "^4.33.0-next.121",
+        "@arcgis/lumina": "^4.33.0-next.121",
+        "@esri/calcite-ui-icons": "4.2.0",
+        "@floating-ui/dom": "^1.6.12",
+        "@floating-ui/utils": "^0.2.8",
+        "@types/sortablejs": "^1.15.8",
+        "color": "^5.0.0",
+        "composed-offset-position": "^0.0.6",
+        "dayjs": "^1.11.13",
+        "focus-trap": "^7.6.2",
+        "interactjs": "^1.10.27",
+        "lodash-es": "^4.17.21",
+        "sortablejs": "^1.15.6",
+        "timezone-groups": "^0.10.4",
+        "type-fest": "^4.30.1"
+      }
+    },
+    "node_modules/@esri/calcite-components/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@esri/calcite-ui-icons": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.2.0.tgz",
+      "integrity": "sha512-GS41gUt1tgnqG+U1a6yDRiKOHmuLST2uyOI7+cJ83JtLJ7CGduH9K6RERabTE2vRYbudaebI8jZgKNSNOHdGzw==",
+      "dev": true,
+      "license": "SEE LICENSE.md",
+      "peer": true,
+      "bin": {
+        "spriter": "bin/spriter.js"
+      }
+    },
     "node_modules/@flatten-js/interval-tree": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@flatten-js/interval-tree/-/interval-tree-1.1.3.tgz",
@@ -1920,6 +2028,14 @@
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/@interactjs/types": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
+      "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2796,6 +2912,81 @@
       "resolved": "https://registry.npmjs.org/@leeoniya/ufuzzy/-/ufuzzy-1.0.18.tgz",
       "integrity": "sha512-5D54A86/VaPvJVf7UWJgy+UyhDtstUxq0iQd8UOZ2TG3NjV2oSoa9m4qW3VsotDD6dH2SNHDQwSPq+IAuudnag==",
       "license": "MIT"
+    },
+    "node_modules/@lit-labs/ssr": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.3.1.tgz",
+      "integrity": "sha512-JlF1PempxvzrGEpRFrF+Ki0MHzR3HA51SK8Zv0cFpW9p0bPW4k0FeCwrElCu371UEpXF7RcaE2wgYaE1az0XKg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit-labs/ssr-dom-shim": "^1.3.0",
+        "@lit/reactive-element": "^2.0.4",
+        "@parse5/tools": "^0.3.0",
+        "@types/node": "^16.0.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^3.1.2",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=13.9.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-client": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.7.tgz",
+      "integrity": "sha512-VvqhY/iif3FHrlhkzEPsuX/7h/NqnfxLwVf0p8ghNIlKegRyRqgeaJevZ57s/u/LiFyKgqksRP5n+LmNvpxN+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit": "^3.1.2",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
+      "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@lit-labs/ssr/node_modules/@types/node": {
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
+      "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.1.0"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
+      "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0"
+      }
     },
     "node_modules/@loaders.gl/3d-tiles": {
       "version": "4.3.3",
@@ -3733,6 +3924,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@parse5/tools": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
+      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3750,6 +3960,17 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@polymer/polymer": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
+      "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@webcomponents/shadycss": "^1.9.1"
+      }
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -5778,7 +5999,6 @@
       "version": "19.1.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
       "integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5810,12 +6030,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
+      "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -5962,6 +6190,215 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vaadin/a11y-base": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.7.11.tgz",
+      "integrity": "sha512-zNjv1ZJSQlxZxK+CPSMG0uet6owb0lw/zKFFLKSFqNRfVqyzW+SViQoxE22StQ5r4dwBxyZXuutu3iisIFwiwA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.7.11",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/checkbox": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.7.11.tgz",
+      "integrity": "sha512-x4UZ+y/eXrK2AOESxkssjqJ+eQO1kZlFpXNfeLOBwIX8+mzmQpnV4B5roC9hHbX4V/J+ijlaY9YnYAZJaz6Acg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.7.11",
+        "@vaadin/component-base": "~24.7.11",
+        "@vaadin/field-base": "~24.7.11",
+        "@vaadin/vaadin-lumo-styles": "~24.7.11",
+        "@vaadin/vaadin-material-styles": "~24.7.11",
+        "@vaadin/vaadin-themable-mixin": "~24.7.11",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/component-base": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.11.tgz",
+      "integrity": "sha512-KyRJT8clpAxExouD7DDDU0b7jxus0W+TqyUgbdHXfyLxKinf9AFsYKRLmRyIusVYRK9mT2QgT82t0m7nuw0bQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/field-base": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.7.11.tgz",
+      "integrity": "sha512-5I1FVw9H/mJp9ZLurx/75/e0rjNLl8UGmNwCvV2pk7ibq7vrNzfa7dZSAgnp/MFBmvyZqHzUeZMpMnTPlfdbQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.7.11",
+        "@vaadin/component-base": "~24.7.11",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/grid": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.7.11.tgz",
+      "integrity": "sha512-gZP7+vQDY6UZu0Lh27oIMzU2KEOcVe4n9336bHB6FaTZkovjMv7xpSfab/MWlHhdI7jETnW214pF5DnIVTHPcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.7.11",
+        "@vaadin/checkbox": "~24.7.11",
+        "@vaadin/component-base": "~24.7.11",
+        "@vaadin/lit-renderer": "~24.7.11",
+        "@vaadin/text-field": "~24.7.11",
+        "@vaadin/vaadin-lumo-styles": "~24.7.11",
+        "@vaadin/vaadin-material-styles": "~24.7.11",
+        "@vaadin/vaadin-themable-mixin": "~24.7.11",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/icon": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.11.tgz",
+      "integrity": "sha512-mJCdsQn7LzYMBdHk5MiyqfXJMe+i4AxBNDqCLC0akvB4pQFT9utWg3ighyPgcAGbnXhelU9pEu9EEhkhOZ2NYg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.7.11",
+        "@vaadin/vaadin-lumo-styles": "~24.7.11",
+        "@vaadin/vaadin-themable-mixin": "~24.7.11",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/input-container": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.7.11.tgz",
+      "integrity": "sha512-6j0S2lG1ZMiVm06NDggHjtZ3AXEANP4wloM/GuhRP8Dot786f9ypkPqfWUqHV/LJPQ+kjpOvD6QsAF/xGm8mJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.7.11",
+        "@vaadin/vaadin-lumo-styles": "~24.7.11",
+        "@vaadin/vaadin-material-styles": "~24.7.11",
+        "@vaadin/vaadin-themable-mixin": "~24.7.11",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.7.11.tgz",
+      "integrity": "sha512-IcUvORztp2USBuZnwwKr1VmamXQZTAs1QTpe+VWf9yglELX6lWAwA3fIAIAFwej+vBiO9v8XHPJK0bDiPiTLKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/text-field": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.7.11.tgz",
+      "integrity": "sha512-vnx/DJPyUzy9yXuj/gWGUHWQGjPIaRfeezV5E7MBpQLrwRcK/uDbnc2MqSsVkLEkClGQangmvDm6svX6KCzq7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.7.11",
+        "@vaadin/component-base": "~24.7.11",
+        "@vaadin/field-base": "~24.7.11",
+        "@vaadin/input-container": "~24.7.11",
+        "@vaadin/vaadin-lumo-styles": "~24.7.11",
+        "@vaadin/vaadin-material-styles": "~24.7.11",
+        "@vaadin/vaadin-themable-mixin": "~24.7.11",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.11.tgz",
+      "integrity": "sha512-MKRqX26XcvfHAWearEOpJmpj0Xg8G6PuMjHgkfqLEz9b9rX4xkIjKjFbrCjddujntmaGbzJfhKxWl+sj9Nkqzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.7.11",
+        "@vaadin/icon": "~24.7.11",
+        "@vaadin/vaadin-themable-mixin": "~24.7.11"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.7.11.tgz",
+      "integrity": "sha512-gqomj16K0vJYRnUIoH6TuvMMpS+XtALcDfkFQ51rj4icF+WpgrhEeFYEIx85Z4MSsE9ODMwytC+Cx4qPWBlcvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.7.11",
+        "@vaadin/vaadin-themable-mixin": "~24.7.11"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.7.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.11.tgz",
+      "integrity": "sha512-/yjaJbMtRJQZgl6XH+aV6vtMt8lJA5NJwE/N4vPL87Wh3xcA+CIigedRlP9B7OeWhjZmrPJfjCdCktNJGq63BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
+      "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -6351,6 +6788,27 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webcomponents/shadycss": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.72",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.72.tgz",
+      "integrity": "sha512-3/A4JwrgkvGBlCxtItjxs8HrNbuTAAl/zlGkV6tC5Fb5k5nk4x2Dqxwl/YnUys5Ch+QB01eJ8Q5K/J2uXfy9Vw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -6588,7 +7046,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -6848,33 +7306,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/buffer-polyfill": {
-      "name": "buffer",
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -7147,6 +7579,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
+      "integrity": "sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^3.0.1",
+        "color-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7166,6 +7613,56 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.0.1.tgz",
+      "integrity": "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/colorbrewer": {
       "version": "1.5.6",
@@ -7196,6 +7693,25 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/composed-offset-position": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
+      "integrity": "sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@floating-ui/utils": "^0.2.5"
       }
     },
     "node_modules/concat-map": {
@@ -7472,6 +7988,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/cssstyle": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
@@ -7623,6 +8147,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -7636,6 +8171,14 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -8649,6 +9192,42 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
@@ -8760,6 +9339,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/focus-trap": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
+      "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -8851,6 +9441,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -9317,7 +9921,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -9406,6 +10010,17 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/interactjs": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
+      "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@interactjs/types": "1.10.27"
+      }
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -10258,6 +10873,43 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lit": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
+      "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
+      "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
+      "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/load-script": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-2.0.0.tgz",
@@ -10338,6 +10990,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -10422,6 +11085,20 @@
       "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/material-colors": {
       "version": "1.2.6",
@@ -10853,6 +11530,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -11793,7 +12512,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11889,7 +12607,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
@@ -12459,7 +13176,6 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -12749,6 +13465,14 @@
       "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -13250,6 +13974,17 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/timezone-groups": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.10.4.tgz",
+      "integrity": "sha512-AnkJYrbb7uPkDCEqGeVJiawZNiwVlSkkeX4jZg1gTEguClhyX+/Ezn07KB6DT29tG3UN418ldmS/W6KqGOTDjg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.12.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -13824,25 +14559,20 @@
       }
     },
     "node_modules/vite-plugin-node-polyfills": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.17.0.tgz",
-      "integrity": "sha512-iPmPn7376e5u6QvoTSJa16hf5Q0DFwHFXJk2uYpsNlmI3JdPms7hWyh55o+OysJ5jo9J5XPhLC9sMOYifwFd1w==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.24.0.tgz",
+      "integrity": "sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==",
       "dev": true,
       "license": "MIT",
-      "workspaces": [
-        "."
-      ],
       "dependencies": {
         "@rollup/plugin-inject": "^5.0.5",
-        "buffer-polyfill": "npm:buffer@^6.0.3",
-        "node-stdlib-browser": "^1.2.0",
-        "process": "^0.11.10"
+        "node-stdlib-browser": "^1.2.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/davidmyersdev"
       },
       "peerDependencies": {
-        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/vitest": {
@@ -14279,6 +15009,24 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xss": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
+      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/taxonium_component/package.json
+++ b/taxonium_component/package.json
@@ -84,7 +84,7 @@
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vite-plugin-css-injected-by-js": "^3.5.2",
-    "vite-plugin-node-polyfills": "^0.17.0",
+    "vite-plugin-node-polyfills": "^0.24.0",
     "vitest": "^3.1.3",
     "web-streams-polyfill": "^4.1.0"
   },


### PR DESCRIPTION
## Summary
- update vite-plugin-node-polyfills to support Vite 6 so installs no longer require --force

## Testing
- `npm install`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_689f4fac79d4832591ae78a6264a03c9