### PR TITLE
Update development instructions to use npm instead of yarn

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,11 +12,11 @@ pre-commit install
 
 ```
 cd taxonium_component
-yarn install
-yarn storybook
+npm install
+npm run storybook
 ```
 
-This should bring up a development server showing Taxonium.
+This should bring up a storybook server showing Taxonium.
 
 ### Linking taxonium_data_handling
 
@@ -24,17 +24,17 @@ A small amount of front-end code comes from the `taxonium_data_handling` repo. I
 
 ```
 cd taxonium_data_handling
-yarn install
-yarn link
+npm install
+npm link
 cd ../taxonium_component
-yarn link taxonium_data_handling
+npm link taxonium_data_handling
 ```
 
 ## For back-end development
 
 ```
 cd taxonium_backend
-yarn install
+npm install
 node server.js --data-file tfci.jsonl.gz
 ```
 
@@ -46,10 +46,10 @@ A small amount of backend code comes from the `taxonium_data_handling` repo. If 
 
 ```
 cd taxonium_data_handling
-yarn install
-yarn link
+npm install
+npm link
 cd ../taxonium_backend
-yarn link taxonium_data_handling
+npm link taxonium_data_handling
 ```
 
 ## Codespaces


### PR DESCRIPTION
## Summary

This PR updates the development instructions in `DEVELOPMENT.md` to use npm commands instead of yarn, aligning with the recent changes in the build process.

## Changes

- Replaced all `yarn` commands with their `npm` equivalents throughout the development documentation
- Removed the requirement to install `taxonium_data_handling` first before building `taxonium_component` 
- Removed references to the `--legacy-peer-deps` flag which is no longer needed

## Context

These changes follow the recent revert commit (#749) that reverted several build-related changes. The documentation now reflects the simplified build process where `taxonium_component` can be built independently without pre-installing the data handling package.