### PR TITLE
fix: align react versions in taxonium_component

### DIFF
--- a/taxonium_component/package-lock.json
+++ b/taxonium_component/package-lock.json
@@ -42,8 +42,10 @@
         "jbrowse": "^0.0.1-security",
         "jsdom": "^26.1.0",
         "playwright": "^1.52.0",
+        "react": "^19.1.1",
         "react-circular-progressbar": "^2.2.0",
         "react-color": "^2.19.3",
+        "react-dom": "^19.1.1",
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-modal": "^3.16.3",
@@ -65,8 +67,8 @@
       },
       "peerDependencies": {
         "prop-types": "^15.8.1",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1"
       }
     },
     "../taxonium_data_handling": {

--- a/taxonium_component/package.json
+++ b/taxonium_component/package.json
@@ -33,8 +33,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.8.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.6",
@@ -67,6 +67,8 @@
     "jbrowse": "^0.0.1-security",
     "jsdom": "^26.1.0",
     "playwright": "^1.52.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
     "react-circular-progressbar": "^2.2.0",
     "react-color": "^2.19.3",
     "react-hot-toast": "^2.5.2",


### PR DESCRIPTION
## Summary
- align `react` and `react-dom` versions to 19.1.1 in taxonium_component
- ensure development uses matching React versions

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_68adb731695483259cd0cdb78ea61efe