### PR TITLE
Simplify Taxonium Component Configuration

### DIFF
--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -28,12 +28,13 @@ const ReactTooltipAny: any = ReactTooltip;
 import { Toaster } from "react-hot-toast";
 import type { DeckSize } from "./types/common";
 import GlobalErrorBoundary from "./components/GlobalErrorBoundary";
+import { normalizeSourceData } from "./utils/normalizeInputFile";
 
 interface SourceData {
-  status: string;
-  filename: string;
+  status?: string;
+  filename?: string;
   filetype: string;
-  data?: string;
+  data?: string | ArrayBuffer;
   [key: string]: unknown;
 }
 
@@ -114,10 +115,21 @@ function Taxonium({
     mouseDownIsMinimap,
   });
 
+  // Normalize sourceData to add smart defaults for status and filename
+  const normalizedSourceData = useMemo(() => {
+    if (!sourceData) return null;
+    try {
+      return normalizeSourceData(sourceData);
+    } catch (error) {
+      console.error("Error normalizing source data:", error);
+      return sourceData; // Fall back to original if normalization fails
+    }
+  }, [sourceData]);
+
   const backend = useBackend(
     backendUrl ? backendUrl : query.backend,
     query.sid,
-    sourceData ?? null
+    normalizedSourceData
   );
   if (!backend) {
     return (

--- a/taxonium_component/src/stories/Taxonium.stories.tsx
+++ b/taxonium_component/src/stories/Taxonium.stories.tsx
@@ -74,6 +74,19 @@ export const LocalData = {
   },
 };
 
+// Simplified version - no need to specify status or filename!
+export const LocalDataSimplified = {
+  args: {
+    sourceData: {
+      data: testTree,
+      filetype: "nwk",
+    },
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
 export const ConfigTree = {
   args: {
     configUrl:
@@ -124,10 +137,40 @@ export const LocalDataWithMetadataNew = {
   },
 };
 
+// Simplified version - no need to specify status or filename for tree or metadata!
+export const LocalDataWithMetadataSimplified = {
+  args: {
+    sourceData: {
+      data: nwk,
+      filetype: "nwk",
+      metadata: {
+        data: metadata_text,
+        filetype: "meta_csv",
+      },
+    },
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
 export const NexusTree = {
   args: {
     sourceData: {
       status: "url_supplied",
+      filename: "https://cov2tree.nyc3.cdn.digitaloceanspaces.com/nexus.tree",
+      filetype: "nexus",
+    },
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
+// Simplified version - status is automatically inferred from URL!
+export const NexusTreeSimplified = {
+  args: {
+    sourceData: {
       filename: "https://cov2tree.nyc3.cdn.digitaloceanspaces.com/nexus.tree",
       filetype: "nexus",
     },

--- a/taxonium_component/src/types/newick.ts
+++ b/taxonium_component/src/types/newick.ts
@@ -1,6 +1,6 @@
 export interface InputFile {
-  status: "url_supplied" | "loaded";
-  filename: string;
+  status?: "url_supplied" | "loaded";
+  filename?: string;
   data?: ArrayBuffer | string;
 }
 

--- a/taxonium_component/src/utils/normalizeInputFile.ts
+++ b/taxonium_component/src/utils/normalizeInputFile.ts
@@ -1,0 +1,118 @@
+import type { InputFile, MetadataFile, NewickFile } from "../types/newick";
+
+/**
+ * Normalizes an InputFile by inferring missing fields with smart defaults.
+ *
+ * Rules:
+ * - If status is not provided, infer it:
+ *   - If data is present -> "loaded"
+ *   - If filename looks like a URL (starts with http/https) -> "url_supplied"
+ *   - Otherwise -> "loaded"
+ * - If filename is not provided:
+ *   - For "loaded" status -> use a default name based on filetype
+ *   - For "url_supplied" status -> filename is required (throw error)
+ */
+export function normalizeInputFile<T extends InputFile>(file: T): T & { status: "url_supplied" | "loaded"; filename: string } {
+  const normalized = { ...file };
+
+  // Infer status if not provided
+  if (!normalized.status) {
+    if (normalized.data !== undefined) {
+      // If data is provided, it's loaded
+      normalized.status = "loaded";
+    } else if (normalized.filename && isUrl(normalized.filename)) {
+      // If filename looks like a URL, treat as url_supplied
+      normalized.status = "url_supplied";
+    } else {
+      // Default to loaded
+      normalized.status = "loaded";
+    }
+  }
+
+  // Infer filename if not provided
+  if (!normalized.filename) {
+    if (normalized.status === "url_supplied") {
+      throw new Error("filename is required when status is 'url_supplied' or when no data is provided");
+    }
+    // Generate a default filename based on filetype
+    const filetype = (normalized as any).filetype || "data";
+    normalized.filename = `data.${filetype}`;
+  }
+
+  return normalized as T & { status: "url_supplied" | "loaded"; filename: string };
+}
+
+/**
+ * Checks if a string looks like a URL
+ */
+function isUrl(str: string): boolean {
+  return str.startsWith("http://") || str.startsWith("https://");
+}
+
+/**
+ * Normalizes a NewickFile and its nested metadata
+ */
+export function normalizeNewickFile(file: NewickFile): NewickFile & { status: "url_supplied" | "loaded"; filename: string } {
+  const normalized = normalizeInputFile(file);
+
+  // Also normalize metadata if present
+  if (normalized.metadata) {
+    normalized.metadata = normalizeInputFile(normalized.metadata as MetadataFile);
+  }
+
+  return normalized;
+}
+
+/**
+ * Normalizes any sourceData object (including non-InputFile formats)
+ * This is a more lenient version for the Taxonium component's SourceData interface
+ */
+export function normalizeSourceData<T extends Record<string, any>>(sourceData: T): T {
+  if (!sourceData) return sourceData;
+
+  const normalized: any = { ...sourceData };
+
+  // Infer status if not provided
+  if (!normalized.status) {
+    if (normalized.data !== undefined) {
+      normalized.status = "loaded";
+    } else if (normalized.filename && isUrl(normalized.filename)) {
+      normalized.status = "url_supplied";
+    } else {
+      normalized.status = "loaded";
+    }
+  }
+
+  // Infer filename if not provided
+  if (!normalized.filename) {
+    if (normalized.status === "url_supplied" && !normalized.data) {
+      throw new Error("filename is required when status is 'url_supplied' or when no data is provided");
+    }
+    // Generate a default filename based on filetype
+    const filetype = normalized.filetype || "data";
+    const ext = getExtensionForFiletype(filetype);
+    normalized.filename = `data.${ext}`;
+  }
+
+  // Also normalize metadata if present
+  if (normalized.metadata && typeof normalized.metadata === "object") {
+    normalized.metadata = normalizeSourceData(normalized.metadata);
+  }
+
+  return normalized as T;
+}
+
+/**
+ * Gets the file extension for a given filetype
+ */
+function getExtensionForFiletype(filetype: string): string {
+  const extensions: Record<string, string> = {
+    'nwk': 'nwk',
+    'nexus': 'nex',
+    'jsonl': 'jsonl',
+    'meta_csv': 'csv',
+    'meta_tsv': 'tsv',
+    'nextstrain': 'json',
+  };
+  return extensions[filetype] || filetype;
+}

--- a/taxonium_component/src/utils/processNewick.ts
+++ b/taxonium_component/src/utils/processNewick.ts
@@ -62,9 +62,12 @@ async function fetch_or_extract(
   whatIsBeingDownloaded: string
 ): Promise<string> {
   if (file_obj.status === "url_supplied") {
+    if (!file_obj.filename) {
+      throw new Error("filename is required for url_supplied status");
+    }
     return do_fetch(file_obj.filename, sendStatusMessage, whatIsBeingDownloaded);
   } else if (file_obj.status === "loaded") {
-    if (file_obj.filename.includes(".gz")) {
+    if (file_obj.filename && file_obj.filename.includes(".gz")) {
       const compressed_data = file_obj.data as ArrayBuffer;
       sendStatusMessage({
         message: "Decompressing compressed " + whatIsBeingDownloaded,


### PR DESCRIPTION
This commit significantly simplifies the Taxonium component API by:

1. Making `status` and `filename` fields optional in InputFile interface
2. Adding smart defaults that infer these values automatically:
   - `status`: Inferred from data presence or URL pattern
   - `filename`: Auto-generated based on filetype when not provided
3. Creating normalizeInputFile utility to handle the inference logic
4. Updating Taxonium component to normalize sourceData before use
5. Adding simplified Storybook examples demonstrating the new API

Benefits:
- Users no longer need to specify `status: "loaded"` for local data
- Notional filenames for metadata are auto-generated
- URL detection is automatic (http/https prefix)
- Backward compatible - existing code still works

Example of simplified API:
Before: { status: "loaded", filename: "test.nwk", data: tree, filetype: "nwk" } After:  { data: tree, filetype: "nwk" }

🤖 Generated with [Claude Code](https://claude.com/claude-code)