### PR TITLE
Tolerate ambiguous bases in codon lookup (default to 'X').

### DIFF
--- a/taxoniumtools/src/taxoniumtools/ushertools.py
+++ b/taxoniumtools/src/taxoniumtools/ushertools.py
@@ -138,8 +138,8 @@ def get_mutations(past_nuc_muts_dict,
             initial_codon = complement(initial_codon)
             final_codon = complement(final_codon)
 
-        initial_codon_trans = codon_table[initial_codon]
-        final_codon_trans = codon_table[final_codon]
+        initial_codon_trans = codon_table.get(initial_codon, 'X')
+        final_codon_trans = codon_table.get(final_codon, 'X')
         if initial_codon_trans != final_codon_trans or disable_check_for_differences:
             #(gene, codon_number + 1, initial_codon_trans, final_codon_trans)
 


### PR DESCRIPTION
usher_to_taxonium with --genbank gets a KeyError when looking up a codon that includes an N or other ambiguous base, e.g. 'GAN', at these two lines of ushertools.py:
```
        initial_codon_trans = codon_table[initial_codon]
        final_codon_trans = codon_table[final_codon]
```
but using `codon_table.get(..._codon, 'X')` allows it to continue and the resulting .jsonl.gz file seems to display fine in taxonium.  Let me know if you would like a test case.