### PR TITLE
Fix race conditions in query parameter updates

### DIFF
--- a/taxonium_component/src/hooks/useSearch.tsx
+++ b/taxonium_component/src/hooks/useSearch.tsx
@@ -247,10 +247,18 @@ const useSearch = ({
     // get a random string key
     const newSearch = getDefaultSearch(config as any);
 
-    setSearchSpec([...searchSpec, newSearch]);
-    setTimeout(() => {
-      setEnabled(newSearch.key, true);
-    }, 50);
+    // Update both srch and enabled in a single updateQuery call to avoid a
+    // race: if the caller's updateQuery implementation defers React state
+    // updates (e.g. React Router v7 uses startTransition), a second call
+    // issued via setTimeout could read stale query params and overwrite the
+    // first one.
+    updateQuery({
+      srch: JSON.stringify([...searchSpec, newSearch]),
+      enabled: JSON.stringify({
+        ...searchesEnabled,
+        [newSearch.key]: true,
+      }),
+    });
   };
 
     const deleteTopLevelSearch = (key: string) => {

--- a/taxonium_website/src/hooks/useQueryAsState.jsx
+++ b/taxonium_website/src/hooks/useQueryAsState.jsx
@@ -32,15 +32,22 @@ const useQueryAsState = (defaultValues = {}) => {
 
   const decodedSearch = useMemo(() => queryParamsToObject(search), [search]);
 
-  const updateRef = useRef({ decodedSearch, pathname });
+  const pathnameRef = useRef(pathname);
   useEffect(() => {
-    updateRef.current = { decodedSearch, pathname };
-  }, [decodedSearch, pathname]);
+    pathnameRef.current = pathname;
+  }, [pathname]);
 
   const updateQuery = useCallback(
     (updatedParams, method = "push") => {
-      const { pathname, decodedSearch } = updateRef.current;
-      const newParams = { ...decodedSearch, ...updatedParams };
+      // Read from window.location rather than a ref synced via useEffect.
+      // React Router v7 wraps navigate's state update in startTransition, so
+      // the useEffect that would update the ref may not have run by the time
+      // a second updateQuery call happens (e.g. two calls in rapid
+      // succession). history.pushState is synchronous, so window.location
+      // always reflects the latest committed URL and prevents the second
+      // call from clobbering the first.
+      const currentSearch = queryParamsToObject(window.location.search);
+      const newParams = { ...currentSearch, ...updatedParams };
 
       // Remove null values from the query parameters
       Object.keys(updatedParams).forEach((key) => {
@@ -51,7 +58,7 @@ const useQueryAsState = (defaultValues = {}) => {
 
       navigate(
         {
-          pathname,
+          pathname: pathnameRef.current,
           search: objectToQueryParams(newParams),
         },
         { replace: method === "replace" }

--- a/taxonium_website_next/src/hooks/useQueryAsState.tsx
+++ b/taxonium_website_next/src/hooks/useQueryAsState.tsx
@@ -41,17 +41,26 @@ const useQueryAsState = (defaultValues: Record<string, any> = {}) => {
     pathnameRef.current = pathname;
   }, [pathname]);
 
+  // Fallback for environments where window is unavailable (SSR). Kept in a
+  // ref so updateQuery's identity doesn't change on every URL update — that
+  // would cascade through downstream useCallback/useEffect deps (e.g.
+  // setxType in Taxonium.tsx) and cause redundant effect re-runs.
+  const decodedSearchRef = useRef(decodedSearch);
+  useEffect(() => {
+    decodedSearchRef.current = decodedSearch;
+  }, [decodedSearch]);
+
   const updateQuery = useCallback(
     (updatedParams: Record<string, any>, method = "push") => {
-      // Read from window.location rather than a ref synced via useEffect.
-      // Routers may defer the React state update (e.g. startTransition), so
-      // a ref that's updated in useEffect can lag behind when updateQuery
-      // is called twice in quick succession. history.pushState is
-      // synchronous, so window.location always reflects the latest URL.
+      // Read from window.location rather than the decodedSearch ref. Routers
+      // may defer the React state update (e.g. startTransition), so a ref
+      // synced via useEffect can lag behind when updateQuery is called twice
+      // in quick succession. history.pushState is synchronous, so
+      // window.location always reflects the latest URL.
       const currentSearch =
         typeof window !== "undefined"
           ? queryParamsToObject(window.location.search)
-          : decodedSearch;
+          : decodedSearchRef.current;
       const newParams = { ...currentSearch, ...updatedParams };
 
       // Remove null values from the query parameters
@@ -70,7 +79,7 @@ const useQueryAsState = (defaultValues: Record<string, any> = {}) => {
         router.push(newUrl);
       }
     },
-    [router, decodedSearch]
+    [router]
   );
 
   const queryWithDefault = useMemo(

--- a/taxonium_website_next/src/hooks/useQueryAsState.tsx
+++ b/taxonium_website_next/src/hooks/useQueryAsState.tsx
@@ -36,15 +36,23 @@ const useQueryAsState = (defaultValues: Record<string, any> = {}) => {
   const search = searchParams?.toString() ? `?${searchParams.toString()}` : "";
   const decodedSearch = useMemo(() => queryParamsToObject(search), [search]);
 
-  const updateRef = useRef({ decodedSearch, pathname });
+  const pathnameRef = useRef(pathname);
   useEffect(() => {
-    updateRef.current = { decodedSearch, pathname };
-  }, [decodedSearch, pathname]);
+    pathnameRef.current = pathname;
+  }, [pathname]);
 
   const updateQuery = useCallback(
     (updatedParams: Record<string, any>, method = "push") => {
-      const { pathname, decodedSearch } = updateRef.current;
-      const newParams = { ...decodedSearch, ...updatedParams };
+      // Read from window.location rather than a ref synced via useEffect.
+      // Routers may defer the React state update (e.g. startTransition), so
+      // a ref that's updated in useEffect can lag behind when updateQuery
+      // is called twice in quick succession. history.pushState is
+      // synchronous, so window.location always reflects the latest URL.
+      const currentSearch =
+        typeof window !== "undefined"
+          ? queryParamsToObject(window.location.search)
+          : decodedSearch;
+      const newParams = { ...currentSearch, ...updatedParams };
 
       // Remove null values from the query parameters
       Object.keys(updatedParams).forEach((key) => {
@@ -54,7 +62,7 @@ const useQueryAsState = (defaultValues: Record<string, any> = {}) => {
       });
 
       const newSearch = objectToQueryParams(newParams);
-      const newUrl = `${pathname}${newSearch}`;
+      const newUrl = `${pathnameRef.current}${newSearch}`;
 
       if (method === "replace") {
         router.replace(newUrl);
@@ -62,7 +70,7 @@ const useQueryAsState = (defaultValues: Record<string, any> = {}) => {
         router.push(newUrl);
       }
     },
-    [router, pathname]
+    [router, decodedSearch]
   );
 
   const queryWithDefault = useMemo(


### PR DESCRIPTION
## Summary
This PR fixes race conditions that occur when query parameters are updated in rapid succession, particularly when using routers that defer React state updates (e.g., React Router v7 with `startTransition`).

## Key Changes

- **useQueryAsState hook**: Changed from using a ref synced via `useEffect` to reading directly from `window.location` when updating query parameters. This ensures we always read the latest committed URL state rather than potentially stale React state.
  - Separated concerns: `pathnameRef` now only tracks pathname changes
  - `updateQuery` now reads current search params from `window.location.search` instead of a potentially out-of-sync ref
  - Updated dependency array to reflect actual dependencies

- **useSearch hook**: Consolidated multiple state updates into a single `updateQuery` call to prevent race conditions when adding new searches.
  - Replaced separate `setSearchSpec` and `setTimeout` + `setEnabled` calls with a single atomic `updateQuery` call
  - This prevents a second rapid call from reading stale query params and overwriting the first update

## Implementation Details

The core issue is that routers may wrap state updates in `startTransition`, deferring the React state update. When `updateQuery` is called twice in quick succession:
1. First call reads stale state from the ref (which hasn't been updated yet)
2. Second call also reads stale state, potentially overwriting the first call's changes

The fix uses `window.location` (which is synchronously updated by `history.pushState`) as the source of truth for current query parameters, ensuring each call sees the latest committed state.

https://claude.ai/code/session_01KvTDRQP5zKXZumWmBAcHE6