### PR TITLE
Show segment number in viral usher tree search results

### DIFF
--- a/taxonium_website_next/src/app/MainApp.tsx
+++ b/taxonium_website_next/src/app/MainApp.tsx
@@ -522,7 +522,10 @@ function MainApp({
                                   )
                                 }
                               >
-                                <span>{tree.organism}</span>
+                                <span>
+                                  {tree.organism}
+                                  {tree.segment && <span className="opacity-60"> (seg. {tree.segment})</span>}
+                                </span>
                                 <span className="ml-2 text-xs opacity-60">
                                   {parseInt(tree.tip_count).toLocaleString()} seqs
                                 </span>
@@ -688,6 +691,7 @@ function MainApp({
                         >
                           <span className="text-gray-800 group-hover:text-gray-900 truncate flex-1">
                             {tree.organism}
+                            {tree.segment && <span className="text-gray-500"> (seg. {tree.segment})</span>}
                           </span>
                           <span className="text-xs text-gray-500 ml-2 whitespace-nowrap">
                             {parseInt(tree.tip_count).toLocaleString()} seqs


### PR DESCRIPTION
## Summary
- Add segment indicator "(seg. N)" to viral usher tree entries in the main page search combobox dropdown
- Add segment indicator to the viral usher trees section on the homepage
- For segmented viruses like Influenza (8 segments per strain), entries were previously indistinguishable — they all showed the same organism name

## Test plan
- [ ] Search for "Influenza" in the main page combobox — results should show "(seg. 1)", "(seg. 4)" etc.
- [ ] Check the viral usher trees section on the homepage with Influenza entries
- [ ] Verify non-segmented viruses (no segment field) display unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)