### PR TITLE
Default-filter to user-placed samples on built tree

### DIFF
--- a/taxonium_website_next/src/app/build/page.tsx
+++ b/taxonium_website_next/src/app/build/page.tsx
@@ -400,6 +400,27 @@ GGGCGGCTTCCGGAATAGCGTACGCGCCTTTGGGTCCACTCGACAGCTTGAGGCATAGGG`);
     }
   }, [mode, manualSpeciesName]);
 
+  // Build the "View in Taxonium" URL. When the user provided sequences, add a
+  // default search filtering to source=user-provided so their placed samples
+  // are highlighted on first load (viral_usher tags placed sequences with
+  // source=user-provided in metadata.tsv).
+  const buildTaxoniumUrl = (fileUrl: string) => {
+    const hasUserSequences = !!(fastaFile || fastaText.trim() || fastaUrl);
+    let url = `https://taxonium.org/?protoUrl=${encodeURIComponent(fileUrl)}&xType=x_dist`;
+    if (hasUserSequences) {
+      const search = [{
+        key: 'placed',
+        type: 'meta_source',
+        method: 'text_exact',
+        text: 'user-provided',
+      }];
+      url += `&srch=${encodeURIComponent(JSON.stringify(search))}`;
+      url += `&enabled=${encodeURIComponent(JSON.stringify({ placed: true }))}`;
+      url += `&zoomToSearch=0`;
+    }
+    return url;
+  };
+
   // Parse URL query parameters on mount
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -1200,9 +1221,7 @@ GGGCGGCTTCCGGAATAGCGTACGCGCCTTTGGGTCCACTCGACAGCTTGAGGCATAGGG`);
 
             // Find the Taxonium file for the "View in Taxonium" button
             const taxoniumFile = jobLogs?.s3_results?.files?.find((f: any) => f.is_taxonium);
-            const taxoniumUrl = taxoniumFile
-              ? `https://taxonium.org/?protoUrl=${encodeURIComponent(taxoniumFile.url)}&xType=x_dist`
-              : null;
+            const taxoniumUrl = taxoniumFile ? buildTaxoniumUrl(taxoniumFile.url) : null;
 
             return (
               <>
@@ -1328,8 +1347,7 @@ GGGCGGCTTCCGGAATAGCGTACGCGCCTTTGGGTCCACTCGACAGCTTGAGGCATAGGG`);
                           </div>
                           <div className="flex gap-2">
                             {file.is_taxonium && (() => {
-                              const encodedUrl = encodeURIComponent(file.url);
-                              const taxoniumUrl = `https://taxonium.org/?protoUrl=${encodedUrl}&xType=x_dist`;
+                              const taxoniumUrl = buildTaxoniumUrl(file.url);
                               return (
                                 <a
                                   href={taxoniumUrl}

--- a/taxonium_website_next/src/app/build/page.tsx
+++ b/taxonium_website_next/src/app/build/page.tsx
@@ -416,6 +416,7 @@ GGGCGGCTTCCGGAATAGCGTACGCGCCTTTGGGTCCACTCGACAGCTTGAGGCATAGGG`);
       }];
       url += `&srch=${encodeURIComponent(JSON.stringify(search))}`;
       url += `&enabled=${encodeURIComponent(JSON.stringify({ placed: true }))}`;
+      url += `&zoomToSearch=0`;
     }
     return url;
   };

--- a/taxonium_website_next/src/app/build/page.tsx
+++ b/taxonium_website_next/src/app/build/page.tsx
@@ -416,7 +416,6 @@ GGGCGGCTTCCGGAATAGCGTACGCGCCTTTGGGTCCACTCGACAGCTTGAGGCATAGGG`);
       }];
       url += `&srch=${encodeURIComponent(JSON.stringify(search))}`;
       url += `&enabled=${encodeURIComponent(JSON.stringify({ placed: true }))}`;
-      url += `&zoomToSearch=0`;
     }
     return url;
   };


### PR DESCRIPTION
## Summary
- The build page's "View in Taxonium" links now append `srch`, `enabled`, and `zoomToSearch=0` URL params when the user supplied sequences, so the viewer opens with a default search filtered to `source=user-provided` and auto-zooms to those samples.
- The trigger condition (`fastaFile || fastaText || fastaUrl`) mirrors viral_usher's behaviour: it only adds the `source` column when extra fasta is present, so we never apply a filter for a column that doesn't exist on plain GenBank builds.
- Covers both the place workflow (which lands on `/build` with a `startingTreeUrl`) and any other build mode where the user adds their own sequences.

## Test plan
- [ ] Run the place workflow with a small fasta — verify the View in Taxonium link includes `srch=...` and lands with placed samples highlighted/zoomed
- [ ] Run a no_genbank build without extra fasta — verify the link is unchanged (no `srch` param)
- [ ] Run a GenBank build with no extra fasta — verify the link is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)