### PR TITLE
Fix Treenome crash from null reference info during layer load

### DIFF
--- a/taxonium_component/src/hooks/useTreenomeLayers.tsx
+++ b/taxonium_component/src/hooks/useTreenomeLayers.tsx
@@ -104,6 +104,12 @@ const useTreenomeLayers = (
       setTreenomeReferenceInfo(computedReference);
     }
   }, [computedReference, treenomeReferenceInfo, setTreenomeReferenceInfo]);
+  // The Deck-level treenomeReferenceInfo prop lags one render behind the
+  // worker output: the worker delivers the reference and the variation data
+  // together, so the layer data is populated before setTreenomeReferenceInfo
+  // has propagated. Fall back to the locally computed reference (which is ready
+  // at the same time as the data) so getColor never dereferences null.
+  const effectiveReferenceInfo = treenomeReferenceInfo || computedReference;
   const ntToX = useCallback(
     (nt: number) => {
       return (
@@ -136,14 +142,14 @@ const useTreenomeLayers = (
     onHover: (info: unknown) => setHoverInfo(info),
     pickable: true,
     getColor: (d: MutationVariationDatum) => {
+      const aaRef = effectiveReferenceInfo?.["aa"];
+      const refResidue = aaRef?.[`${d.m.gene!}:${d.m.residue_pos!}`];
       if (cov2Genes !== null) {
-        return d.m.new_residue !==
-          treenomeReferenceInfo["aa"][`${d.m.gene!}:${d.m.residue_pos!}`]
+        return d.m.new_residue !== refResidue
           ? colorHook.toRGB(d.m.new_residue!)
           : cov2Genes[d.m.gene!][2].map((c: number) => 245 - 0.2 * (245 - c));
       } else {
-        return d.m.new_residue !==
-          treenomeReferenceInfo["aa"][`${d.m.gene!}:${d.m.residue_pos!}`]
+        return d.m.new_residue !== refResidue
           ? colorHook.toRGB(d.m.new_residue!)
           : [245, 245, 245];
       }
@@ -200,7 +206,7 @@ const useTreenomeLayers = (
         aaWidth,
       ],
       getWidth: [aaWidth],
-      getColor: [treenomeReferenceInfo, colorHook, cov2Genes],
+      getColor: [effectiveReferenceInfo, colorHook, cov2Genes],
     },
     getPolygonOffset: myGetPolygonOffset,
   };
@@ -240,7 +246,8 @@ const useTreenomeLayers = (
           break;
       }
       if (cov2Genes !== null) {
-        if (d.m.new_residue === treenomeReferenceInfo["nt"][d.m.residue_pos!]) {
+        const ntRef = effectiveReferenceInfo?.["nt"];
+        if (ntRef && d.m.new_residue === ntRef[d.m.residue_pos!]) {
           const gene = ntToCov2Gene(d.m.residue_pos!);
           if (gene !== null) {
             return cov2Genes[gene][2].map((c: number) => 245 - 0.2 * (245 - c));
@@ -301,7 +308,7 @@ const useTreenomeLayers = (
         ntWidth,
       ],
       getWidth: [ntWidth],
-      getColor: [treenomeReferenceInfo, colorHook, cov2Genes],
+      getColor: [effectiveReferenceInfo, colorHook, cov2Genes],
     },
     getPolygonOffset: myGetPolygonOffset,
   };


### PR DESCRIPTION
## Problem

The Treenome browser plugin crashes on load with:

```
update of LineLayer({id: 'browser-loaded-main-aa'}): Cannot read properties of null (reading 'aa')
    at getColor (...)
```

(Reported by users via Russ; the genome browser panel fails to render.)

## Root cause

`getColor` for the variation `LineLayer`s in `useTreenomeLayers` reads the **Deck-level** `treenomeReferenceInfo` prop. That prop lags one render behind the worker output:

- The treenome worker delivers the reference **and** the variation/layer data in the same message (`useTreenomeLayerData`), so `layerDataAa`/`layerDataNt` become non-empty immediately.
- The reference only reaches Deck-level state later, via the follow-up `setTreenomeReferenceInfo` effect.

In the in-between render the layer data is populated while the prop is still `null`, so deck.gl calls `getColor` on real rows and evaluates `null["aa"]` / `null["nt"]` → crash. React 19's batching makes this race fire reliably (the file moved to React 19 + TS in #700).

## Fix

Use the locally computed reference (`computedReference`, ready at the same time as the data) as a fallback, and guard the lookups against null:

- `const effectiveReferenceInfo = treenomeReferenceInfo || computedReference;`
- `getColor` (aa + nt) reads via optional chaining off `effectiveReferenceInfo`.
- `updateTriggers.getColor` now keys on `effectiveReferenceInfo` so colors refresh once the reference arrives.

No behavioural change once the reference is loaded; it only removes the null-deref during the load window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)