### PR TITLE
Fix dead V1 redirect for .pb uploads (#830)

### DIFF
--- a/taxonium_website_next/src/hooks/useInputHelper.jsx
+++ b/taxonium_website_next/src/hooks/useInputHelper.jsx
@@ -94,8 +94,7 @@ export const useInputHelper = ({
         window.alert(
           "It looks like you are trying to load a Taxonium V1 proto. We will now redirect you to the V1 site. Please retry the upload from there."
         );
-        window.location.href =
-          "https://cov2tree-git-v1-theosanderson.vercel.app/";
+        window.location.href = "https://cov2tree-v1.vercel.app/";
       } else {
         const result = reader.result;
         file.supplyType = "file";


### PR DESCRIPTION
Fixes #830.

Dropping a `.pb` file into the web viewer alerted the user and redirected to `https://cov2tree-git-v1-theosanderson.vercel.app/`, an old Vercel git-branch preview URL that was garbage-collected and now 404s (`DEPLOYMENT_NOT_FOUND`).

**Fix:** rebuilt and redeployed the `v1` branch as a standalone Vercel project at a stable URL — **https://cov2tree-v1.vercel.app** — and updated the redirect in `taxonium_website_next/src/hooks/useInputHelper.jsx` to point there.

Note: the V1 site's *default* cov2tree dataset no longer auto-loads (its data files were git-fat placeholders in the branch), but the `.pb` **upload** flow — the subject of the issue — works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)