### PR TITLE
Fix blank Treenome Browser (duplicate react-dom bundled into JBrowse chunk)

### DIFF
--- a/taxonium_component/vite.config.js
+++ b/taxonium_component/vite.config.js
@@ -34,10 +34,19 @@ export default defineConfig({
 
     rollupOptions: {
       // Make sure to externalize deps that shouldn't be bundled
+      // Subpaths must be listed too: a bare "react-dom" entry only matches
+      // that exact specifier, so deps importing "react-dom/client" (e.g.
+      // JBrowse) would otherwise get a second copy of React DOM bundled in,
+      // which throws "Incompatible React versions" when the host app is on a
+      // different React build.
       external: [
         "react",
         "react-dom",
+        "react-dom/client",
+        "react-dom/server",
+        "react-dom/server.browser",
         "react/jsx-runtime", // Important addition!
+        "react/jsx-dev-runtime",
         "prop-types",
       ],
 
@@ -46,7 +55,11 @@ export default defineConfig({
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
+          "react-dom/client": "ReactDOM",
+          "react-dom/server": "ReactDOMServer",
+          "react-dom/server.browser": "ReactDOMServer",
           "react/jsx-runtime": "jsxRuntime",
+          "react/jsx-dev-runtime": "jsxRuntime",
           "prop-types": "PropTypes",
         },
         // Ensure chunking is handled properly


### PR DESCRIPTION
## The bug

On https://www.taxonium.org/sars-cov-2/public, ticking **Treenome Browser** gives an empty white panel. The checkbox itself is fine — the URL gains `?treenomeEnabled=true` and the layout switches to the 3/4 split — but JBrowse and the treenome layers never appear, with no error shown to the user.

## Root cause

Rollup's `external` matches specifiers **exactly**, so the bare `"react-dom"` entry in `taxonium_component/vite.config.js` does not cover subpath imports. JBrowse's dependency tree imports `react-dom/client` (and `react-dom/server.browser`), so a complete private copy of react-dom from `taxonium_component/node_modules` gets bundled into `dist/JBrowsePanel-*.js` — its sourcemap lists `node_modules/react-dom/cjs/react-dom-client.production.js`, and the deployed chunk `_next/static/chunks/6d197b8556c0a19f.js` contains both `LinearGenomeView` and react-dom's version check.

The Next site runs Next 15.5's vendored React **19.2.0-canary**, while that bundled react-dom is **19.1.1**, so evaluating the chunk throws:

```
Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
  - react:      19.2.0-canary-0bdb9206-20250818
  - react-dom:  19.1.1
```

Because the throw happens inside the `React.lazy` import, it is rethrown at render, and `JBrowseErrorBoundary` renders `""` for any error other than the two known file-format ones — hence a blank panel and total silence.

## The fix

Externalise the `react-dom` / `react` subpaths too, with matching `globals` entries for the UMD build.

## Verification

Local A/B against `api.cov2tree.org` with `taxonium_website_next`, same commit, only `vite.config.js` differing:

| build | result |
| --- | --- |
| before | blank panel, `Incompatible React versions` in console — production symptom reproduced |
| after | JBrowse ruler + track selector render, treenome mutation layers draw |

The JBrowse chunk also shrinks from 7.0 MB to 5.4 MB.

## Follow-ups (not in this PR)

- `JBrowseErrorBoundary` rendering `""` on unrecognised errors is what made this fail invisibly; a visible message or a `console.error` would have surfaced it immediately.
- Pre-existing and unrelated: `treenomeWorker.js` throws `Cannot read properties of undefined (reading 'parent_id')` when handed an empty node set — `pre_order([])` returns `[null]`, then `lookup[null].parent_id` throws (`useTreenomeLayerData.tsx` posts even when `data.data.nodes` is `[]`). Harmless but noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)