### PR TITLE
Fit the initial x view to the tree instead of assuming a fixed scale

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,8 @@ jobs:
         cd ../taxonium_component
         npm ci
         npm run build
+        npm test
+        npm run check-types
       env:
         NODE_OPTIONS: --max-old-space-size=8192
 

--- a/taxonium_backend/server.js
+++ b/taxonium_backend/server.js
@@ -462,14 +462,14 @@ const loadData = async () => {
     status: "finalising",
   });
 
-  if (config.no_file) {
-    importing.generateConfig(config, processedData);
-  }
-
   processedData.initial_view = importing.getInitialViewConfig(
     processedData.nodes,
     { minY: processedData.overallMinY, maxY: processedData.overallMaxY }
   );
+
+  if (config.no_file) {
+    importing.generateConfig(config, processedData);
+  }
 
   processedData.genes = new Set(
     processedData.mutations.map((mutation) => mutation.gene)

--- a/taxonium_backend/server.js
+++ b/taxonium_backend/server.js
@@ -218,10 +218,9 @@ if (command_options.config_override) {
 
 app.get("/config", function (req, res) {
   config.num_nodes = processedData.nodes.length;
-  config.initial_x =
-    (processedData.overallMinX + processedData.overallMaxX) / 2;
-  config.initial_y =
-    (processedData.overallMinY + processedData.overallMaxY) / 2;
+  // initial_view is worked out once, when the tree is loaded, because it
+  // involves a pass over every node.
+  Object.assign(config, processedData.initial_view);
   config.initial_zoom = -2;
   config.genes = processedData.genes;
   config = { ...config, ...processedData.overwrite_config };
@@ -468,6 +467,11 @@ const loadData = async () => {
   if (config.no_file) {
     importing.generateConfig(config, processedData);
   }
+
+  processedData.initial_view = importing.getInitialViewConfig(
+    processedData.nodes,
+    { minY: processedData.overallMinY, maxY: processedData.overallMaxY }
+  );
 
   processedData.genes = new Set(
     processedData.mutations.map((mutation) => mutation.gene)

--- a/taxonium_backend/server.js
+++ b/taxonium_backend/server.js
@@ -218,8 +218,6 @@ if (command_options.config_override) {
 
 app.get("/config", function (req, res) {
   config.num_nodes = processedData.nodes.length;
-  // initial_view is worked out once, when the tree is loaded, because it
-  // involves a pass over every node.
   Object.assign(config, processedData.initial_view);
   config.initial_zoom = -2;
   config.genes = processedData.genes;

--- a/taxonium_component/package.json
+++ b/taxonium_component/package.json
@@ -29,7 +29,8 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "prop-types": "^15.8.1",

--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -13,7 +13,7 @@ import useHoverDetails from "./hooks/useHoverDetails";
 import type { DeckGLRef } from "@deck.gl/react";
 import useBackend from "./hooks/useBackend";
 import usePerNodeFunctions from "./hooks/usePerNodeFunctions";
-import type { DynamicDataWithLookup } from "./types/backend";
+import type { Config, DynamicDataWithLookup } from "./types/backend";
 import useConfig from "./hooks/useConfig";
 import { useSettings } from "./hooks/useSettings";
 import { MdArrowBack, MdArrowUpward } from "react-icons/md";
@@ -72,6 +72,12 @@ const default_query = getDefaultQuery();
 type TaxoniumInnerProps = TaxoniumProps & {
   query: Query;
   updateQuery: (q: Partial<Query>) => void;
+};
+
+type FitContext = {
+  config: Config;
+  xType: string;
+  treenomeEnabled: boolean;
 };
 
 function TaxoniumInner({
@@ -163,7 +169,12 @@ function TaxoniumInner({
   //TODO: this is always true for now
   (config as any).enable_ns_download = true;
 
-  const xType = query.xType ? query.xType : "x_dist";
+  const availableXTypes = config.x_accessors;
+  const xType =
+    availableXTypes?.length &&
+    (!query.xType || !availableXTypes.includes(query.xType))
+      ? availableXTypes[0]
+      : query.xType || "x_dist";
 
   const setxType = useCallback(
     (xType: string) => {
@@ -200,46 +211,72 @@ function TaxoniumInner({
     }
   }, [data.base_data, setxType]);
 
-  // Fit the view to the tree once its extent (from the config) and the
-  // viewport size are both known. A change of tree, x axis or treenome layout
-  // refits outright; a resize refits only while the view is still where the
-  // last fit left it. `view` is a new object every render, so the ref rather
-  // than the dependency array decides whether there is anything new to do.
-  const [initialViewReady, setInitialViewReady] = useState(false);
+  const [readyContext, setReadyContext] = useState<FitContext | null>(null);
   const lastFitted = useRef<{
-    config: unknown;
-    xType: string;
-    treenomeEnabled: boolean;
-    deckSize: DeckSize;
+    context: FitContext;
+    width: number;
+    height: number;
   } | null>(null);
+  const treenomeEnabled = Boolean(settings.treenomeEnabled);
+  const initialViewReady =
+    readyContext?.config === config &&
+    readyContext.xType === xType &&
+    readyContext.treenomeEnabled === treenomeEnabled;
+  const fitToRanges = view.fitToRanges;
+
+  // Dataset changes reset both axes; axis and layout changes reset x only.
   useEffect(() => {
     if (config.title === "loading") {
       return;
     }
     const xRange = config.x_ranges ? config.x_ranges[xType] : undefined;
     if (!xRange || !config.y_range) {
-      // A backend that doesn't report the extent of the tree: nothing to
-      // fit to.
-      setInitialViewReady(true);
+      setReadyContext({ config, xType, treenomeEnabled });
       return;
     }
-    if (!deckSize.width || isNaN(deckSize.width)) {
-      return;
-    }
-    const treenomeEnabled = Boolean(settings.treenomeEnabled);
     const last = lastFitted.current;
-    const isNewFit =
-      !last ||
-      last.config !== config ||
-      last.xType !== xType ||
-      last.treenomeEnabled !== treenomeEnabled;
-    if (!isNewFit && last.deckSize === deckSize) {
+    const datasetChanged = !last || last.context.config !== config;
+    const xTypeChanged = !last || last.context.xType !== xType;
+    const layoutChanged =
+      !last || last.context.treenomeEnabled !== treenomeEnabled;
+    const widthChanged = !last || last.width !== deckSize.width;
+    const heightChanged = !last || last.height !== deckSize.height;
+    const xFit =
+      datasetChanged || xTypeChanged || layoutChanged
+        ? "force"
+        : widthChanged
+        ? "if-unmoved"
+        : "skip";
+    const yFit = datasetChanged
+      ? "force"
+      : heightChanged
+      ? "if-unmoved"
+      : "skip";
+    if (xFit === "skip" && yFit === "skip") {
       return;
     }
-    lastFitted.current = { config, xType, treenomeEnabled, deckSize };
-    view.fitToRanges(xRange, config.y_range, { onlyIfUnmoved: !isNewFit });
-    setInitialViewReady(true);
-  }, [config, xType, deckSize, settings.treenomeEnabled, view]);
+
+    const context = { config, xType, treenomeEnabled };
+    const fitted = fitToRanges(xRange, config.y_range, {
+      x: xFit,
+      y: yFit,
+    });
+    if (fitted) {
+      lastFitted.current = {
+        context,
+        width: deckSize.width,
+        height: deckSize.height,
+      };
+      setReadyContext(context);
+    }
+  }, [
+    config,
+    xType,
+    deckSize.width,
+    deckSize.height,
+    treenomeEnabled,
+    fitToRanges,
+  ]);
 
   const search = useSearch({
     data,

--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -200,13 +200,14 @@ function TaxoniumInner({
     }
   }, [data.base_data, setxType]);
 
-  // Fit the x axis to the tree once we know both how wide the tree is (from
-  // the config) and how wide the viewport is. Refit when the x axis switches
+  // Fit the view to the tree once we know both how big the tree is (from the
+  // config) and how big the viewport is. Refit when the x axis switches
   // between divergence and time, since the two have unrelated scales, and
   // when the treenome browser opens or closes, which changes how much of the
-  // window the tree gets. A resize refits too, but only while the x axis is
+  // window the tree gets. A resize refits too, but only while the view is
   // still where the last fit left it, so that it never undoes the user's own
   // panning and zooming.
+  const [initialViewReady, setInitialViewReady] = useState(false);
   const lastFitted = useRef<{
     config: unknown;
     xType: string;
@@ -214,8 +215,17 @@ function TaxoniumInner({
     deckSize: DeckSize;
   } | null>(null);
   useEffect(() => {
+    if (config.title === "loading") {
+      return;
+    }
     const xRange = config.x_ranges ? config.x_ranges[xType] : undefined;
-    if (!xRange || !deckSize.width || isNaN(deckSize.width)) {
+    if (!xRange) {
+      // A backend that doesn't report the extent of the tree: nothing to fit
+      // to, so leave the view at its default.
+      setInitialViewReady(true);
+      return;
+    }
+    if (!deckSize.width || isNaN(deckSize.width)) {
       return;
     }
     const treenomeEnabled = Boolean(settings.treenomeEnabled);
@@ -230,6 +240,7 @@ function TaxoniumInner({
     }
     lastFitted.current = { config, xType, treenomeEnabled, deckSize };
     view.fitToRanges(xRange, config.y_range, { onlyIfUnmoved: !isNewFit });
+    setInitialViewReady(true);
   }, [config, xType, deckSize, settings.treenomeEnabled, view]);
 
   const search = useSearch({
@@ -243,6 +254,7 @@ function TaxoniumInner({
     deckSize,
     xType,
     settings,
+    initialViewReady,
   });
 
   const [sidebarOpen, setSidebarOpen] = useState(!sidePanelHiddenByDefault);

--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -200,6 +200,38 @@ function TaxoniumInner({
     }
   }, [data.base_data, setxType]);
 
+  // Fit the x axis to the tree once we know both how wide the tree is (from
+  // the config) and how wide the viewport is. Refit when the x axis switches
+  // between divergence and time, since the two have unrelated scales, and
+  // when the treenome browser opens or closes, which changes how much of the
+  // window the tree gets. A resize refits too, but only while the x axis is
+  // still where the last fit left it, so that it never undoes the user's own
+  // panning and zooming.
+  const lastFitted = useRef<{
+    config: unknown;
+    xType: string;
+    treenomeEnabled: boolean;
+    deckSize: DeckSize;
+  } | null>(null);
+  useEffect(() => {
+    const xRange = config.x_ranges ? config.x_ranges[xType] : undefined;
+    if (!xRange || !deckSize.width || isNaN(deckSize.width)) {
+      return;
+    }
+    const treenomeEnabled = Boolean(settings.treenomeEnabled);
+    const last = lastFitted.current;
+    const isNewFit =
+      !last ||
+      last.config !== config ||
+      last.xType !== xType ||
+      last.treenomeEnabled !== treenomeEnabled;
+    if (!isNewFit && last.deckSize === deckSize) {
+      return;
+    }
+    lastFitted.current = { config, xType, treenomeEnabled, deckSize };
+    view.fitToRanges(xRange, config.y_range, { onlyIfUnmoved: !isNewFit });
+  }, [config, xType, deckSize, settings.treenomeEnabled, view]);
+
   const search = useSearch({
     data,
     config,

--- a/taxonium_component/src/Taxonium.tsx
+++ b/taxonium_component/src/Taxonium.tsx
@@ -200,13 +200,11 @@ function TaxoniumInner({
     }
   }, [data.base_data, setxType]);
 
-  // Fit the view to the tree once we know both how big the tree is (from the
-  // config) and how big the viewport is. Refit when the x axis switches
-  // between divergence and time, since the two have unrelated scales, and
-  // when the treenome browser opens or closes, which changes how much of the
-  // window the tree gets. A resize refits too, but only while the view is
-  // still where the last fit left it, so that it never undoes the user's own
-  // panning and zooming.
+  // Fit the view to the tree once its extent (from the config) and the
+  // viewport size are both known. A change of tree, x axis or treenome layout
+  // refits outright; a resize refits only while the view is still where the
+  // last fit left it. `view` is a new object every render, so the ref rather
+  // than the dependency array decides whether there is anything new to do.
   const [initialViewReady, setInitialViewReady] = useState(false);
   const lastFitted = useRef<{
     config: unknown;
@@ -219,9 +217,9 @@ function TaxoniumInner({
       return;
     }
     const xRange = config.x_ranges ? config.x_ranges[xType] : undefined;
-    if (!xRange) {
-      // A backend that doesn't report the extent of the tree: nothing to fit
-      // to, so leave the view at its default.
+    if (!xRange || !config.y_range) {
+      // A backend that doesn't report the extent of the tree: nothing to
+      // fit to.
       setInitialViewReady(true);
       return;
     }

--- a/taxonium_component/src/hooks/useGetDynamicData.tsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.tsx
@@ -128,8 +128,10 @@ function useGetDynamicData(
                     new_result.base_data = addNodeLookup(nodeResult);
                 } else {
                   if (!prevData.base_data || prevData.base_data_is_invalid) {
+                      // No bounds means the whole tree: this is the overview
+                      // the minimap draws.
                       queryNodes(
-                        null,
+                        { xType },
                         (base_result: NodesResponse) => {
                           const nodeBase = base_result as NodeLookupData;
                           setDynamicData((prevData) => {

--- a/taxonium_component/src/hooks/useGetDynamicData.tsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.tsx
@@ -128,7 +128,6 @@ function useGetDynamicData(
                     new_result.base_data = addNodeLookup(nodeResult);
                 } else {
                   if (!prevData.base_data || prevData.base_data_is_invalid) {
-                      // Whole-tree overview for the minimap.
                       queryNodes(
                         { xType },
                         (base_result: NodesResponse) => {

--- a/taxonium_component/src/hooks/useGetDynamicData.tsx
+++ b/taxonium_component/src/hooks/useGetDynamicData.tsx
@@ -128,8 +128,7 @@ function useGetDynamicData(
                     new_result.base_data = addNodeLookup(nodeResult);
                 } else {
                   if (!prevData.base_data || prevData.base_data_is_invalid) {
-                      // No bounds means the whole tree: this is the overview
-                      // the minimap draws.
+                      // Whole-tree overview for the minimap.
                       queryNodes(
                         { xType },
                         (base_result: NodesResponse) => {

--- a/taxonium_component/src/hooks/useSearch.tsx
+++ b/taxonium_component/src/hooks/useSearch.tsx
@@ -27,6 +27,11 @@ interface UseSearchParams {
   deckSize: { width: number; height: number } | null;
   xType: string;
   settings: Settings;
+  /**
+   * False until the view has been fitted to the tree. Zooming to a search
+   * waits for that, since the fit would otherwise overwrite it.
+   */
+  initialViewReady: boolean;
 }
 
 const useSearch = ({
@@ -40,6 +45,7 @@ const useSearch = ({
   deckSize,
   xType,
   settings,
+  initialViewReady,
 }: UseSearchParams): SearchState => {
   const { singleSearch } = backend;
 
@@ -278,7 +284,7 @@ const useSearch = ({
     lineColors[index % lineColors.length];
 
   useEffect(() => {
-    if (zoomToSearch && deckSize) {
+    if (zoomToSearch && deckSize && initialViewReady) {
       const { index } = zoomToSearch;
       const relevant = searchResults[searchSpec[index].key];
       if (!relevant) {
@@ -329,6 +335,7 @@ const useSearch = ({
     zoomToSearch,
     searchResults,
     deckSize,
+    initialViewReady,
     config.num_nodes,
     settings.treenomeEnabled,
     searchSpec,

--- a/taxonium_component/src/hooks/useSearch.tsx
+++ b/taxonium_component/src/hooks/useSearch.tsx
@@ -27,7 +27,6 @@ interface UseSearchParams {
   deckSize: { width: number; height: number } | null;
   xType: string;
   settings: Settings;
-  /** Zooming to a search waits for the initial fit, which would otherwise overwrite it. */
   initialViewReady: boolean;
 }
 

--- a/taxonium_component/src/hooks/useSearch.tsx
+++ b/taxonium_component/src/hooks/useSearch.tsx
@@ -27,10 +27,7 @@ interface UseSearchParams {
   deckSize: { width: number; height: number } | null;
   xType: string;
   settings: Settings;
-  /**
-   * False until the view has been fitted to the tree. Zooming to a search
-   * waits for that, since the fit would otherwise overwrite it.
-   */
+  /** Zooming to a search waits for the initial fit, which would otherwise overwrite it. */
   initialViewReady: boolean;
 }
 

--- a/taxonium_component/src/hooks/useView.fit.test.tsx
+++ b/taxonium_component/src/hooks/useView.fit.test.tsx
@@ -1,145 +1,208 @@
-import { describe, it, expect } from "vitest";
 import React from "react";
-import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import type { Settings } from "../types/settings";
+import type { DeckSize } from "../types/common";
 import useView from "./useView";
 
 const act = (React as any).act as (cb: () => void) => void;
+const roots: Root[] = [];
 
-// Minimal renderHook: @testing-library/react is not a dependency here.
-function renderHook<T>(hook: () => T) {
-  const result = { current: undefined as unknown as T };
+function renderView(
+  initialSettings: Settings,
+  initialSize: DeckSize,
+  mouseDownIsMinimap = false,
+) {
+  let props = {
+    settings: initialSettings,
+    deckSize: initialSize,
+    mouseDownIsMinimap,
+  };
+  const result = {
+    current: undefined as unknown as ReturnType<typeof useView>,
+  };
   const Probe = () => {
-    result.current = hook();
+    result.current = useView(props);
     return null;
   };
-  const container = document.createElement("div");
-  document.body.appendChild(container);
-  const root = createRoot(container);
-  act(() => {
-    root.render(React.createElement(Probe));
-  });
-  return { result };
+  const root = createRoot(document.createElement("div"));
+  roots.push(root);
+  const render = () => act(() => root.render(React.createElement(Probe)));
+  render();
+  return {
+    result,
+    rerender(next: Partial<typeof props>) {
+      props = { ...props, ...next };
+      render();
+    },
+  };
 }
 
-const settings = { minimapEnabled: true, treenomeEnabled: false } as any;
+afterEach(() => {
+  act(() => roots.splice(0).forEach((root) => root.unmount()));
+});
+
+const settings = {
+  minimapEnabled: true,
+  treenomeEnabled: false,
+} as Settings;
 const deckSize = { width: 1000, height: 500 };
-
-const setup = (s = settings, size = deckSize) =>
-  renderHook(() =>
-    useView({ settings: s, deckSize: size, mouseDownIsMinimap: false })
-  );
-
-// Every view state this hook produces has a zoom per axis.
-const zoomOf = (vs: { zoom: number | [number, number] }) =>
-  vs.zoom as [number, number];
-
 const xRange = { min: 0, max: 2805, robust_max: 800 };
 const yRange = { min: 0, max: 2400 };
+const zoomOf = (zoom: number | [number, number]) => zoom as [number, number];
 
 describe("fitToRanges", () => {
-  it("centres on the robust range and zooms to fill 80% of the width", () => {
-    const { result } = setup();
-    act(() => {
-      result.current.fitToRanges(xRange, yRange);
-    });
-    const vs = result.current.viewState;
-    expect(vs.target[0]).toBe(400);
-    expect(vs.target[1]).toBe(1200);
-    expect(zoomOf(vs)[0]).toBeCloseTo(Math.log2((1000 * 0.8) / 800), 10);
-    expect(zoomOf(vs)[1]).toBeCloseTo(Math.log2((500 * 0.96) / 2400), 10);
+  it("fits the main view to the robust x range and full y range", () => {
+    const { result } = renderView(settings, deckSize);
+    act(() => result.current.fitToRanges(xRange, yRange));
+
+    expect(result.current.viewState.target).toEqual([400, 1200]);
+    expect(zoomOf(result.current.viewState.zoom)[0]).toBeCloseTo(
+      Math.log2((1000 * 0.8) / 800),
+      10,
+    );
+    expect(zoomOf(result.current.viewState.zoom)[1]).toBeCloseTo(
+      Math.log2((500 * 0.96) / 2400),
+      10,
+    );
   });
 
-  it("fits the minimap to the same extents", () => {
-    const { result } = setup();
-    act(() => {
-      result.current.fitToRanges(xRange, yRange);
-    });
-    const mm = result.current.viewState.minimap!;
-    expect(mm.target).toEqual([400, 1200]);
-    expect(zoomOf(mm)[0]).toBeCloseTo(Math.log2((1000 * 0.2 * 0.8) / 800), 10);
-    expect(zoomOf(mm)[1]).toBeCloseTo(
+  it("uses the robust x range for the minimap", () => {
+    const { result } = renderView(settings, deckSize);
+    act(() => result.current.fitToRanges(xRange, yRange));
+
+    const minimap = result.current.viewState.minimap!;
+    expect(minimap.target).toEqual([400, 1200]);
+    expect(zoomOf(minimap.zoom)[0]).toBeCloseTo(
+      Math.log2((1000 * 0.2 * 0.8) / 800),
+      10,
+    );
+    expect(zoomOf(minimap.zoom)[1]).toBeCloseTo(
       Math.log2((500 * 0.35 * 0.96) / 2400),
-      10
+      10,
     );
   });
 
-  it("uses 40% of the width when the treenome browser is open", () => {
-    const { result } = setup({ ...settings, treenomeEnabled: true });
-    act(() => {
-      result.current.fitToRanges(xRange, yRange);
-    });
-    expect(zoomOf(result.current.viewState)[0]).toBeCloseTo(
+  it("accounts for the treenome browser width", () => {
+    const { result } = renderView(
+      { ...settings, treenomeEnabled: true },
+      deckSize,
+    );
+    act(() => result.current.fitToRanges(xRange, yRange));
+
+    expect(zoomOf(result.current.viewState.zoom)[0]).toBeCloseTo(
       Math.log2((1000 * 0.4 * 0.8) / 800),
-      10
+      10,
     );
   });
 
-  it("refits when unmoved but not after the user pans", () => {
-    const { result } = setup();
-    act(() => {
-      result.current.fitToRanges(xRange, yRange);
-    });
-    act(() => {
+  it("refits an unmoved x axis while preserving a moved y axis", () => {
+    const { result, rerender } = renderView(settings, deckSize);
+    act(() => result.current.fitToRanges(xRange, yRange));
+    act(() =>
+      result.current.setViewState((current) => ({
+        ...current,
+        target: [current.target[0], 12345],
+      })),
+    );
+
+    rerender({ deckSize: { width: 500, height: 500 } });
+    act(() =>
+      result.current.fitToRanges(xRange, yRange, {
+        x: "if-unmoved",
+        y: "skip",
+      }),
+    );
+
+    expect(zoomOf(result.current.viewState.zoom)[0]).toBeCloseTo(-1, 10);
+    expect(result.current.viewState.target).toEqual([400, 12345]);
+  });
+
+  it("preserves y when x is forcibly refitted", () => {
+    const { result } = renderView(settings, deckSize);
+    act(() => result.current.fitToRanges(xRange, yRange));
+    act(() =>
+      result.current.setViewState((current) => ({
+        ...current,
+        zoom: [zoomOf(current.zoom)[0], 7],
+        target: [current.target[0], 321],
+      })),
+    );
+    act(() =>
       result.current.fitToRanges(
         { min: 0, max: 100, robust_max: 100 },
         yRange,
-        { onlyIfUnmoved: true }
+        { x: "force", y: "skip" },
+      ),
+    );
+
+    expect(result.current.viewState.target).toEqual([50, 321]);
+    expect(zoomOf(result.current.viewState.zoom)[1]).toBe(7);
+  });
+
+  it("updates the reset fit after a moved view is resized", () => {
+    const { result, rerender } = renderView(settings, deckSize);
+    act(() => result.current.fitToRanges(xRange, yRange));
+    act(() =>
+      result.current.setViewState((current) => ({
+        ...current,
+        target: [12345, current.target[1]],
+      })),
+    );
+
+    rerender({ deckSize: { width: 500, height: 500 } });
+    act(() =>
+      result.current.fitToRanges(xRange, yRange, {
+        x: "if-unmoved",
+        y: "skip",
+      }),
+    );
+    expect(result.current.viewState.target[0]).toBe(12345);
+    act(() => result.current.zoomReset());
+
+    expect(result.current.viewState.target).toEqual([400, 1200]);
+    expect(zoomOf(result.current.viewState.zoom)[0]).toBeCloseTo(-1, 10);
+    expect(result.current.viewState["browser-main"]?.target).toEqual([0, 1200]);
+  });
+
+  it.each([
+    { width: NaN, height: 500 },
+    { width: 1000, height: NaN },
+    { width: 0, height: 500 },
+    { width: 1000, height: 0 },
+  ])("rejects an invalid deck size: %o", (invalidSize) => {
+    const { result } = renderView(settings, invalidSize);
+    const before = result.current.viewState;
+
+    let fitted: boolean | undefined;
+    act(() => {
+      fitted = result.current.fitToRanges(xRange, yRange);
+    });
+
+    expect(fitted).toBe(false);
+    expect(result.current.viewState).toBe(before);
+  });
+
+  it("rejects degenerate ranges", () => {
+    const { result } = renderView(settings, deckSize);
+    const before = result.current.viewState;
+
+    act(() => {
+      expect(
+        result.current.fitToRanges({ min: 5, max: 5, robust_max: 5 }, yRange),
+      ).toBe(false);
+      expect(result.current.fitToRanges(xRange, { min: 0, max: 0 })).toBe(
+        false,
       );
     });
-    expect(result.current.viewState.target[0]).toBe(50);
 
-    act(() => {
-      result.current.setViewState((vs: any) => ({
-        ...vs,
-        target: [12345, vs.target[1]],
-      }));
-    });
-    act(() => {
-      result.current.fitToRanges({ min: 0, max: 10, robust_max: 10 }, yRange, {
-        onlyIfUnmoved: true,
-      });
-    });
-    expect(result.current.viewState.target[0]).toBe(12345);
-  });
-
-  // A tree whose nodes all share an x or a y position has nothing to fit to,
-  // so the view is left alone rather than zoomed to an infinite scale.
-  it("does nothing for a degenerate range or an unknown deck size", () => {
-    const { result } = setup();
-    const before = result.current.viewState;
-    act(() => {
-      result.current.fitToRanges({ min: 5, max: 5, robust_max: 5 }, yRange);
-      result.current.fitToRanges(xRange, { min: 0, max: 0 });
-    });
     expect(result.current.viewState).toBe(before);
-
-    const nan = setup(settings, { width: NaN, height: NaN });
-    const nanBefore = nan.result.current.viewState;
-    act(() => {
-      nan.result.current.fitToRanges(xRange, yRange);
-    });
-    expect(nan.result.current.viewState).toBe(nanBefore);
   });
 
-  it("resets the zoom to the fitted view, or the default before a fit", () => {
-    const { result } = setup();
-    act(() => {
-      result.current.zoomReset();
-    });
-    expect(result.current.viewState.zoom).toEqual([0, -2]);
+  it("uses the default reset before fitting", () => {
+    const { result } = renderView(settings, deckSize);
+    act(() => result.current.zoomReset());
 
-    act(() => {
-      result.current.fitToRanges(xRange, yRange);
-    });
-    const fitted = result.current.viewState;
-    act(() => {
-      result.current.setViewState((vs: any) => ({ ...vs, target: [9, 9] }));
-    });
-    act(() => {
-      result.current.zoomReset();
-    });
-    expect(result.current.viewState.target).toEqual(fitted.target);
-    expect(result.current.viewState.zoom).toEqual(fitted.zoom);
-    expect(result.current.viewState.minimap).toEqual(fitted.minimap);
+    expect(result.current.viewState.zoom).toEqual([0, -2]);
   });
 });

--- a/taxonium_component/src/hooks/useView.fit.test.tsx
+++ b/taxonium_component/src/hooks/useView.fit.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import useView from "./useView";
+
+const act = (React as any).act as (cb: () => void) => void;
+
+// Minimal renderHook: @testing-library/react is not a dependency here.
+function renderHook<T>(hook: () => T) {
+  const result = { current: undefined as unknown as T };
+  const Probe = () => {
+    result.current = hook();
+    return null;
+  };
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(Probe));
+  });
+  return { result };
+}
+
+const settings = { minimapEnabled: true, treenomeEnabled: false } as any;
+const deckSize = { width: 1000, height: 500 };
+
+const setup = (s = settings, size = deckSize) =>
+  renderHook(() =>
+    useView({ settings: s, deckSize: size, mouseDownIsMinimap: false })
+  );
+
+// Every view state this hook produces has a zoom per axis.
+const zoomOf = (vs: { zoom: number | [number, number] }) =>
+  vs.zoom as [number, number];
+
+const xRange = { min: 0, max: 2805, robust_max: 800 };
+const yRange = { min: 0, max: 2400 };
+
+describe("fitToRanges", () => {
+  it("centres on the robust range and zooms to fill 80% of the width", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.fitToRanges(xRange, yRange);
+    });
+    const vs = result.current.viewState;
+    expect(vs.target[0]).toBe(400);
+    expect(vs.target[1]).toBe(1200);
+    expect(zoomOf(vs)[0]).toBeCloseTo(Math.log2((1000 * 0.8) / 800), 10);
+    expect(zoomOf(vs)[1]).toBeCloseTo(Math.log2((500 * 0.96) / 2400), 10);
+  });
+
+  it("fits the minimap to the same extents", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.fitToRanges(xRange, yRange);
+    });
+    const mm = result.current.viewState.minimap!;
+    expect(mm.target).toEqual([400, 1200]);
+    expect(zoomOf(mm)[0]).toBeCloseTo(Math.log2((1000 * 0.2 * 0.8) / 800), 10);
+    expect(zoomOf(mm)[1]).toBeCloseTo(
+      Math.log2((500 * 0.35 * 0.96) / 2400),
+      10
+    );
+  });
+
+  it("uses 40% of the width when the treenome browser is open", () => {
+    const { result } = setup({ ...settings, treenomeEnabled: true });
+    act(() => {
+      result.current.fitToRanges(xRange, yRange);
+    });
+    expect(zoomOf(result.current.viewState)[0]).toBeCloseTo(
+      Math.log2((1000 * 0.4 * 0.8) / 800),
+      10
+    );
+  });
+
+  it("refits when unmoved but not after the user pans", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.fitToRanges(xRange, yRange);
+    });
+    act(() => {
+      result.current.fitToRanges(
+        { min: 0, max: 100, robust_max: 100 },
+        yRange,
+        { onlyIfUnmoved: true }
+      );
+    });
+    expect(result.current.viewState.target[0]).toBe(50);
+
+    act(() => {
+      result.current.setViewState((vs: any) => ({
+        ...vs,
+        target: [12345, vs.target[1]],
+      }));
+    });
+    act(() => {
+      result.current.fitToRanges({ min: 0, max: 10, robust_max: 10 }, yRange, {
+        onlyIfUnmoved: true,
+      });
+    });
+    expect(result.current.viewState.target[0]).toBe(12345);
+  });
+
+  // A tree whose nodes all share an x or a y position has nothing to fit to,
+  // so the view is left alone rather than zoomed to an infinite scale.
+  it("does nothing for a degenerate range or an unknown deck size", () => {
+    const { result } = setup();
+    const before = result.current.viewState;
+    act(() => {
+      result.current.fitToRanges({ min: 5, max: 5, robust_max: 5 }, yRange);
+      result.current.fitToRanges(xRange, { min: 0, max: 0 });
+    });
+    expect(result.current.viewState).toBe(before);
+
+    const nan = setup(settings, { width: NaN, height: NaN });
+    const nanBefore = nan.result.current.viewState;
+    act(() => {
+      nan.result.current.fitToRanges(xRange, yRange);
+    });
+    expect(nan.result.current.viewState).toBe(nanBefore);
+  });
+
+  it("resets the zoom to the fitted view, or the default before a fit", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.zoomReset();
+    });
+    expect(result.current.viewState.zoom).toEqual([0, -2]);
+
+    act(() => {
+      result.current.fitToRanges(xRange, yRange);
+    });
+    const fitted = result.current.viewState;
+    act(() => {
+      result.current.setViewState((vs: any) => ({ ...vs, target: [9, 9] }));
+    });
+    act(() => {
+      result.current.zoomReset();
+    });
+    expect(result.current.viewState.target).toEqual(fitted.target);
+    expect(result.current.viewState.zoom).toEqual(fitted.zoom);
+    expect(result.current.viewState.minimap).toEqual(fitted.minimap);
+  });
+});

--- a/taxonium_component/src/hooks/useView.tsx
+++ b/taxonium_component/src/hooks/useView.tsx
@@ -72,6 +72,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
   const fittedView = useRef<{
     xZoom: number;
     xTarget: number;
+    yZoom: number | null;
     yTarget: number | null;
   } | null>(null);
 
@@ -180,13 +181,14 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
     [zoomAxis]
   );
 
-  // Fit the x axis (and the minimap, which shows both axes) to the extent of
-  // the tree. x coordinates have no fixed scale -- they are branch lengths in
-  // whatever units the tree was built with -- so the only way to know how far
-  // to zoom out is to be told the range the data covers.
+  // Fit the view (main and minimap) to the extent of the tree. Neither axis
+  // has a fixed scale -- x is branch length in whatever units the tree was
+  // built with, and y is spread over a range that depends on how many nodes
+  // there are -- so the only way to know how far to zoom out is to be told
+  // the range the data covers.
   //
-  // With onlyIfUnmoved the fit is abandoned if the x axis is no longer where
-  // the last fit left it, i.e. if the user has panned or zoomed it themselves.
+  // With onlyIfUnmoved the fit is abandoned if the view is no longer where
+  // the last fit left it, i.e. if the user has panned or zoomed themselves.
   const fitToRanges = useCallback(
     (
       xRange: { min: number; robust_max: number },
@@ -206,46 +208,69 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
         : deckSize.width;
       const xZoom = zoomToFit(mainWidth, xSpan);
 
-      const ySpan = yRange ? yRange.max - yRange.min : 0;
-      const yCentre = yRange ? (yRange.min + yRange.max) / 2 : null;
-      const minimap: SubViewState =
-        ySpan > 0 && yCentre !== null
+      // The y extent is optional: a backend may report the x extent alone.
+      const yFit =
+        yRange && yRange.max > yRange.min
           ? {
-              zoom: [
-                zoomToFit(deckSize.width * MINIMAP_WIDTH_FRACTION, xSpan),
-                zoomToFit(deckSize.height * MINIMAP_HEIGHT_FRACTION, ySpan),
-              ] as [number, number],
-              target: [xCentre, yCentre] as [number, number],
+              span: yRange.max - yRange.min,
+              centre: (yRange.min + yRange.max) / 2,
+              zoom: zoomToFit(deckSize.height, yRange.max - yRange.min),
             }
-          : minimapViewState.current;
+          : null;
 
-      // Deliberately checked before setViewState rather than inside its
-      // updater: the updater has to stay pure, and it can be run twice.
+      const minimap: SubViewState = yFit
+        ? {
+            zoom: [
+              zoomToFit(deckSize.width * MINIMAP_WIDTH_FRACTION, xSpan),
+              zoomToFit(deckSize.height * MINIMAP_HEIGHT_FRACTION, yFit.span),
+            ] as [number, number],
+            target: [xCentre, yFit.centre] as [number, number],
+          }
+        : minimapViewState.current;
+
       const previous = fittedView.current;
       const current = viewStateRef.current;
-      if (
-        onlyIfUnmoved &&
-        previous &&
-        ((current.zoom as [number, number])[0] !== previous.xZoom ||
-          current.target[0] !== previous.xTarget)
-      ) {
-        return;
+      if (onlyIfUnmoved && previous) {
+        const currentZoom = current.zoom as [number, number];
+        const moved =
+          currentZoom[0] !== previous.xZoom ||
+          current.target[0] !== previous.xTarget ||
+          (previous.yZoom !== null && currentZoom[1] !== previous.yZoom) ||
+          (previous.yTarget !== null && current.target[1] !== previous.yTarget);
+        if (moved) {
+          return;
+        }
       }
 
-      fittedView.current = { xZoom, xTarget: xCentre, yTarget: yCentre };
+      fittedView.current = {
+        xZoom,
+        xTarget: xCentre,
+        yZoom: yFit ? yFit.zoom : null,
+        yTarget: yFit ? yFit.centre : null,
+      };
       minimapViewState.current = minimap;
 
-      setViewState(
-        (vs: ViewStateType) =>
-          ({
-            ...vs,
-            zoom: [xZoom, (vs.zoom as [number, number])[1]] as [number, number],
-            target: [xCentre, vs.target[1]] as [number, number],
-            minimap,
-          }) as ViewStateType
-      );
+      // Routed through onViewStateChange so that the views that follow the
+      // main one (the minimap, and the treenome browser's rows) are brought
+      // along with it.
+      onViewStateChange({
+        viewId: "main",
+        interactionState: {},
+        oldViewState: current,
+        viewState: {
+          ...current,
+          zoom: [
+            xZoom,
+            yFit ? yFit.zoom : (current.zoom as [number, number])[1],
+          ] as [number, number],
+          target: [xCentre, yFit ? yFit.centre : current.target[1]] as [
+            number,
+            number
+          ],
+        },
+      });
     },
-    [deckSize, settings.treenomeEnabled]
+    [deckSize, settings.treenomeEnabled, onViewStateChange]
   );
 
   const zoomReset = useCallback(() => {
@@ -256,7 +281,8 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
     if (fittedView.current) {
       reset.zoom = [
         fittedView.current.xZoom,
-        (defaultViewState.zoom as [number, number])[1],
+        fittedView.current.yZoom ??
+          (defaultViewState.zoom as [number, number])[1],
       ];
       reset.target = [
         fittedView.current.xTarget,

--- a/taxonium_component/src/hooks/useView.tsx
+++ b/taxonium_component/src/hooks/useView.tsx
@@ -4,6 +4,7 @@ import type { OrthographicViewProps } from "@deck.gl/core";
 import type { Settings } from "../types/settings";
 import type { DeckSize } from "../types/common";
 import type { SubViewState, ViewState } from "../types/view";
+import type { XRange, YRange } from "../types/backend";
 
 interface ViewStateChangeParameters<ViewStateT> {
   viewId: string;
@@ -18,11 +19,10 @@ interface StyledViewProps extends OrthographicViewProps {
 
 const identityMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
-// Fractions of the deck that each view occupies. These must match the
-// OrthographicView definitions below.
-const MINIMAP_WIDTH_FRACTION = 0.2;
-const MINIMAP_HEIGHT_FRACTION = 0.35;
-const MAIN_WIDTH_FRACTION_WITH_TREENOME = 0.4;
+// Percentages of the deck that each view occupies.
+const MINIMAP_WIDTH = 20;
+const MINIMAP_HEIGHT = 35;
+const MAIN_WIDTH_WITH_TREENOME = 40;
 
 // Proportion of each axis that the fitted tree fills, the rest being blank
 // space split between the two edges. x is deliberately roomier than y.
@@ -73,10 +73,8 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
   // What the tree was last fitted to, so that resetting the zoom goes back to
   // the whole tree rather than to a hardcoded guess.
   const fittedView = useRef<{
-    xZoom: number;
-    xTarget: number;
-    yZoom: number | null;
-    yTarget: number | null;
+    zoom: [number, number];
+    target: [number, number];
   } | null>(null);
 
   const baseViewState = useMemo(() => ({ ...viewState }), [viewState]);
@@ -96,10 +94,10 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
       vs.push(
         new OrthographicView({
           id: "minimap",
-          x: "79%",
+          x: `${99 - MINIMAP_WIDTH}%`,
           y: "1%",
-          width: "20%",
-          height: "35%",
+          width: `${MINIMAP_WIDTH}%`,
+          height: `${MINIMAP_HEIGHT}%`,
           borderWidth: "1px",
           controller: controllerProps,
         } as StyledViewProps)
@@ -110,15 +108,15 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
         new OrthographicView({
           id: "browser-axis",
           controller: false,
-          x: "40%",
+          x: `${MAIN_WIDTH_WITH_TREENOME}%`,
           y: "0%",
-          width: "60%",
+          width: `${100 - MAIN_WIDTH_WITH_TREENOME}%`,
         } as StyledViewProps),
         new OrthographicView({
           id: "browser-main",
           controller: controllerProps,
-          x: "40%",
-          width: "60%",
+          x: `${MAIN_WIDTH_WITH_TREENOME}%`,
+          width: `${100 - MAIN_WIDTH_WITH_TREENOME}%`,
         } as StyledViewProps)
       );
     }
@@ -126,7 +124,9 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
       new OrthographicView({
         id: "main",
         controller: controllerProps,
-        width: settings.treenomeEnabled ? "40%" : "100%",
+        width: settings.treenomeEnabled
+          ? `${MAIN_WIDTH_WITH_TREENOME}%`
+          : "100%",
         initialViewState: viewState,
       } as StyledViewProps)
     );
@@ -184,86 +184,67 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
     [zoomAxis]
   );
 
-  // Fit the view (main and minimap) to the extent of the tree. Neither axis
-  // has a fixed scale -- x is branch length in whatever units the tree was
-  // built with, and y is spread over a range that depends on how many nodes
-  // there are -- so the only way to know how far to zoom out is to be told
-  // the range the data covers.
-  //
-  // With onlyIfUnmoved the fit is abandoned if the view is no longer where
-  // the last fit left it, i.e. if the user has panned or zoomed themselves.
+  // Fit the main view and the minimap to the extent of the tree. With
+  // onlyIfUnmoved the fit is skipped if the user has panned or zoomed since
+  // the last fit.
   const fitToRanges = useCallback(
     (
-      xRange: { min: number; robust_max: number },
-      yRange?: { min: number; max: number },
+      xRange: XRange,
+      yRange: YRange,
       { onlyIfUnmoved = false }: { onlyIfUnmoved?: boolean } = {}
     ) => {
       if (!deckSize || !deckSize.width || isNaN(deckSize.width)) {
         return;
       }
       const xSpan = xRange.robust_max - xRange.min;
-      if (!(xSpan > 0)) {
+      const ySpan = yRange.max - yRange.min;
+      if (!(xSpan > 0) || !(ySpan > 0)) {
         return;
       }
-      const xCentre = (xRange.min + xRange.robust_max) / 2;
-      const mainWidth = settings.treenomeEnabled
-        ? deckSize.width * MAIN_WIDTH_FRACTION_WITH_TREENOME
-        : deckSize.width;
-      const xZoom = zoomToFit(mainWidth, xSpan, X_FILL_FRACTION);
 
-      // The y extent is optional: a backend may report the x extent alone.
-      const yFit =
-        yRange && yRange.max > yRange.min
-          ? {
-              span: yRange.max - yRange.min,
-              centre: (yRange.min + yRange.max) / 2,
-              zoom: zoomToFit(
-                deckSize.height,
-                yRange.max - yRange.min,
-                Y_FILL_FRACTION
-              ),
-            }
-          : null;
-
-      const minimap: SubViewState = yFit
-        ? {
-            zoom: [
-              zoomToFit(
-                deckSize.width * MINIMAP_WIDTH_FRACTION,
-                xSpan,
-                X_FILL_FRACTION
-              ),
-              zoomToFit(
-                deckSize.height * MINIMAP_HEIGHT_FRACTION,
-                yFit.span,
-                Y_FILL_FRACTION
-              ),
-            ] as [number, number],
-            target: [xCentre, yFit.centre] as [number, number],
-          }
-        : minimapViewState.current;
-
-      const previous = fittedView.current;
       const current = viewStateRef.current;
+      const previous = fittedView.current;
       if (onlyIfUnmoved && previous) {
-        const currentZoom = current.zoom as [number, number];
+        const zoom = current.zoom as [number, number];
         const moved =
-          currentZoom[0] !== previous.xZoom ||
-          current.target[0] !== previous.xTarget ||
-          (previous.yZoom !== null && currentZoom[1] !== previous.yZoom) ||
-          (previous.yTarget !== null && current.target[1] !== previous.yTarget);
+          zoom[0] !== previous.zoom[0] ||
+          zoom[1] !== previous.zoom[1] ||
+          current.target[0] !== previous.target[0] ||
+          current.target[1] !== previous.target[1];
         if (moved) {
           return;
         }
       }
 
+      const mainWidth = settings.treenomeEnabled
+        ? (deckSize.width * MAIN_WIDTH_WITH_TREENOME) / 100
+        : deckSize.width;
+      const target: [number, number] = [
+        (xRange.min + xRange.robust_max) / 2,
+        (yRange.min + yRange.max) / 2,
+      ];
       fittedView.current = {
-        xZoom,
-        xTarget: xCentre,
-        yZoom: yFit ? yFit.zoom : null,
-        yTarget: yFit ? yFit.centre : null,
+        zoom: [
+          zoomToFit(mainWidth, xSpan, X_FILL_FRACTION),
+          zoomToFit(deckSize.height, ySpan, Y_FILL_FRACTION),
+        ],
+        target,
       };
-      minimapViewState.current = minimap;
+      minimapViewState.current = {
+        zoom: [
+          zoomToFit(
+            (deckSize.width * MINIMAP_WIDTH) / 100,
+            xSpan,
+            X_FILL_FRACTION
+          ),
+          zoomToFit(
+            (deckSize.height * MINIMAP_HEIGHT) / 100,
+            ySpan,
+            Y_FILL_FRACTION
+          ),
+        ],
+        target,
+      };
 
       // Routed through onViewStateChange so that the views that follow the
       // main one (the minimap, and the treenome browser's rows) are brought
@@ -271,40 +252,18 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
       onViewStateChange({
         viewId: "main",
         interactionState: {},
-        oldViewState: current,
-        viewState: {
-          ...current,
-          zoom: [
-            xZoom,
-            yFit ? yFit.zoom : (current.zoom as [number, number])[1],
-          ] as [number, number],
-          target: [xCentre, yFit ? yFit.centre : current.target[1]] as [
-            number,
-            number
-          ],
-        },
+        viewState: { ...current, ...fittedView.current },
       });
     },
     [deckSize, settings.treenomeEnabled, onViewStateChange]
   );
 
   const zoomReset = useCallback(() => {
-    const reset: ViewStateType = {
+    setViewState({
       ...defaultViewState,
+      ...fittedView.current,
       minimap: minimapViewState.current,
-    };
-    if (fittedView.current) {
-      reset.zoom = [
-        fittedView.current.xZoom,
-        fittedView.current.yZoom ??
-          (defaultViewState.zoom as [number, number])[1],
-      ];
-      reset.target = [
-        fittedView.current.xTarget,
-        fittedView.current.yTarget ?? defaultViewState.target[1],
-      ] as [number, number];
-    }
-    setViewState(reset);
+    });
   }, []);
 
   return {
@@ -337,8 +296,8 @@ export interface View {
   modelMatrix: number[];
   zoomIncrement: (increment: number, axis?: string) => void;
   fitToRanges: (
-    xRange: { min: number; robust_max: number },
-    yRange?: { min: number; max: number },
+    xRange: XRange,
+    yRange: YRange,
     options?: { onlyIfUnmoved?: boolean }
   ) => void;
   xzoom: number;

--- a/taxonium_component/src/hooks/useView.tsx
+++ b/taxonium_component/src/hooks/useView.tsx
@@ -24,17 +24,20 @@ const MINIMAP_WIDTH_FRACTION = 0.2;
 const MINIMAP_HEIGHT_FRACTION = 0.35;
 const MAIN_WIDTH_FRACTION_WITH_TREENOME = 0.4;
 
-// Proportion of the fitted range left as blank space at each edge.
-const FIT_MARGIN = 0.02;
+// Proportion of each axis that the fitted tree fills, the rest being blank
+// space split between the two edges. x is deliberately roomier than y.
+const X_FILL_FRACTION = 0.8;
+const Y_FILL_FRACTION = 0.96;
 
 const defaultMinimapViewState: SubViewState = {
   zoom: -3,
   target: [250, 1000],
 };
 
-// Zoom level at which a range of `span` world units fills `pixels` pixels.
-const zoomToFit = (pixels: number, span: number) =>
-  Math.log2(pixels / (span * (1 + 2 * FIT_MARGIN)));
+// Zoom level at which a range of `span` world units covers the given
+// proportion of `pixels` pixels.
+const zoomToFit = (pixels: number, span: number, fill: number) =>
+  Math.log2((pixels * fill) / span);
 
 const defaultViewState: ViewState = {
   zoom: [0, -2],
@@ -206,7 +209,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
       const mainWidth = settings.treenomeEnabled
         ? deckSize.width * MAIN_WIDTH_FRACTION_WITH_TREENOME
         : deckSize.width;
-      const xZoom = zoomToFit(mainWidth, xSpan);
+      const xZoom = zoomToFit(mainWidth, xSpan, X_FILL_FRACTION);
 
       // The y extent is optional: a backend may report the x extent alone.
       const yFit =
@@ -214,15 +217,27 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
           ? {
               span: yRange.max - yRange.min,
               centre: (yRange.min + yRange.max) / 2,
-              zoom: zoomToFit(deckSize.height, yRange.max - yRange.min),
+              zoom: zoomToFit(
+                deckSize.height,
+                yRange.max - yRange.min,
+                Y_FILL_FRACTION
+              ),
             }
           : null;
 
       const minimap: SubViewState = yFit
         ? {
             zoom: [
-              zoomToFit(deckSize.width * MINIMAP_WIDTH_FRACTION, xSpan),
-              zoomToFit(deckSize.height * MINIMAP_HEIGHT_FRACTION, yFit.span),
+              zoomToFit(
+                deckSize.width * MINIMAP_WIDTH_FRACTION,
+                xSpan,
+                X_FILL_FRACTION
+              ),
+              zoomToFit(
+                deckSize.height * MINIMAP_HEIGHT_FRACTION,
+                yFit.span,
+                Y_FILL_FRACTION
+              ),
             ] as [number, number],
             target: [xCentre, yFit.centre] as [number, number],
           }

--- a/taxonium_component/src/hooks/useView.tsx
+++ b/taxonium_component/src/hooks/useView.tsx
@@ -19,13 +19,10 @@ interface StyledViewProps extends OrthographicViewProps {
 
 const identityMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
-// Percentages of the deck that each view occupies.
 const MINIMAP_WIDTH = 20;
 const MINIMAP_HEIGHT = 35;
 const MAIN_WIDTH_WITH_TREENOME = 40;
 
-// Proportion of each axis that the fitted tree fills, the rest being blank
-// space split between the two edges. x is deliberately roomier than y.
 const X_FILL_FRACTION = 0.8;
 const Y_FILL_FRACTION = 0.96;
 
@@ -34,10 +31,10 @@ const defaultMinimapViewState: SubViewState = {
   target: [250, 1000],
 };
 
-// Zoom level at which a range of `span` world units covers the given
-// proportion of `pixels` pixels.
 const zoomToFit = (pixels: number, span: number, fill: number) =>
   Math.log2((pixels * fill) / span);
+
+type FitMode = "force" | "if-unmoved" | "skip";
 
 const defaultViewState: ViewState = {
   zoom: [0, -2],
@@ -60,18 +57,11 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
   const [mouseXY, setMouseXY] = useState([0, 0]);
   const [zoomAxis, setZoomAxis] = useState("Y");
 
-  // The minimap always shows the whole tree, so its view state is not the
-  // user's to change. It is kept in a ref because onViewStateChange has to
-  // reapply it on every interaction without being re-created each time.
   const minimapViewState = useRef<SubViewState>(defaultMinimapViewState);
 
-  // The current view state, readable from callbacks that must not depend on
-  // it (a dependency on it would re-create them on every pan and zoom).
   const viewStateRef = useRef<ViewStateType>(viewState);
   viewStateRef.current = viewState;
 
-  // What the tree was last fitted to, so that resetting the zoom goes back to
-  // the whole tree rather than to a hardcoded guess.
   const fittedView = useRef<{
     zoom: [number, number];
     target: [number, number];
@@ -85,7 +75,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
       scrollZoom: true,
       zoomAxis: "Y",
     }),
-    []
+    [],
   );
 
   const views = useMemo(() => {
@@ -100,7 +90,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
           height: `${MINIMAP_HEIGHT}%`,
           borderWidth: "1px",
           controller: controllerProps,
-        } as StyledViewProps)
+        } as StyledViewProps),
       );
     }
     if (settings.treenomeEnabled) {
@@ -117,7 +107,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
           controller: controllerProps,
           x: `${MAIN_WIDTH_WITH_TREENOME}%`,
           width: `${100 - MAIN_WIDTH_WITH_TREENOME}%`,
-        } as StyledViewProps)
+        } as StyledViewProps),
       );
     }
     vs.push(
@@ -128,7 +118,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
           ? `${MAIN_WIDTH_WITH_TREENOME}%`
           : "100%",
         initialViewState: viewState,
-      } as StyledViewProps)
+      } as StyledViewProps),
     );
     if (settings.treenomeEnabled) {
       vs.push(
@@ -137,20 +127,17 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
           controller: controllerProps,
           width: "100%",
           initialViewState: viewState,
-        } as StyledViewProps)
+        } as StyledViewProps),
       );
     }
     return vs;
   }, [controllerProps, viewState, settings]);
 
-  const onViewStateChange = useCallback(
-    ({ viewState: newViewState, viewId, requestIsFromMinimapPan }: ViewStateChangeParameters<ViewStateType> & { requestIsFromMinimapPan?: boolean }) => {
-      if (mouseDownIsMinimap && !requestIsFromMinimapPan) {
-        return false;
-      }
-
-      newViewState.minimap = minimapViewState.current;
-      newViewState["browser-main"] = {
+  const withDependentViews = useCallback((newViewState: ViewStateType) => {
+    return {
+      ...newViewState,
+      minimap: minimapViewState.current,
+      "browser-main": {
         zoom: [
           -3,
           Array.isArray(newViewState.zoom)
@@ -158,113 +145,152 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
             : (newViewState.zoom as number),
         ],
         target: [0, (newViewState as any).target[1]],
-      };
-      setViewState(newViewState);
+      },
+    } as ViewStateType;
+  }, []);
 
-      return newViewState;
+  const onViewStateChange = useCallback(
+    ({
+      viewState: newViewState,
+      requestIsFromMinimapPan,
+    }: ViewStateChangeParameters<ViewStateType> & {
+      requestIsFromMinimapPan?: boolean;
+    }) => {
+      if (mouseDownIsMinimap && !requestIsFromMinimapPan) {
+        return false;
+      }
+
+      const nextViewState = withDependentViews(newViewState);
+      setViewState(nextViewState);
+      return nextViewState;
     },
-    [mouseDownIsMinimap]
+    [mouseDownIsMinimap, withDependentViews],
   );
 
   const zoomIncrement = useCallback(
     (increment: number, axis: string | undefined = zoomAxis) => {
-        setViewState((vs: ViewStateType) => {
-          const newZoom = [...(vs.zoom as [number, number])];
-          if (axis === "X") {
-            newZoom[0] = newZoom[0] + increment;
-          } else if (axis === "Y") {
-            newZoom[1] = newZoom[1] + increment;
-          } else {
-            newZoom[0] = newZoom[0] + increment;
-            newZoom[1] = newZoom[1] + increment;
-          }
-          return { ...vs, zoom: newZoom } as ViewStateType;
-        });
+      setViewState((vs: ViewStateType) => {
+        const newZoom = [...(vs.zoom as [number, number])];
+        if (axis === "X") {
+          newZoom[0] = newZoom[0] + increment;
+        } else if (axis === "Y") {
+          newZoom[1] = newZoom[1] + increment;
+        } else {
+          newZoom[0] = newZoom[0] + increment;
+          newZoom[1] = newZoom[1] + increment;
+        }
+        return withDependentViews({ ...vs, zoom: newZoom } as ViewStateType);
+      });
     },
-    [zoomAxis]
+    [zoomAxis, withDependentViews],
   );
 
-  // Fit the main view and the minimap to the extent of the tree. With
-  // onlyIfUnmoved the fit is skipped if the user has panned or zoomed since
-  // the last fit.
   const fitToRanges = useCallback(
     (
       xRange: XRange,
       yRange: YRange,
-      { onlyIfUnmoved = false }: { onlyIfUnmoved?: boolean } = {}
+      { x = "force", y = "force" }: { x?: FitMode; y?: FitMode } = {},
     ) => {
-      if (!deckSize || !deckSize.width || isNaN(deckSize.width)) {
-        return;
+      if (
+        !deckSize ||
+        !Number.isFinite(deckSize.width) ||
+        !Number.isFinite(deckSize.height) ||
+        deckSize.width <= 0 ||
+        deckSize.height <= 0
+      ) {
+        return false;
       }
       const xSpan = xRange.robust_max - xRange.min;
       const ySpan = yRange.max - yRange.min;
-      if (!(xSpan > 0) || !(ySpan > 0)) {
-        return;
+      if (
+        !Number.isFinite(xSpan) ||
+        !Number.isFinite(ySpan) ||
+        xSpan <= 0 ||
+        ySpan <= 0
+      ) {
+        return false;
       }
 
       const current = viewStateRef.current;
       const previous = fittedView.current;
-      if (onlyIfUnmoved && previous) {
-        const zoom = current.zoom as [number, number];
-        const moved =
-          zoom[0] !== previous.zoom[0] ||
-          zoom[1] !== previous.zoom[1] ||
-          current.target[0] !== previous.target[0] ||
-          current.target[1] !== previous.target[1];
-        if (moved) {
-          return;
-        }
-      }
+      const currentZoom = Array.isArray(current.zoom)
+        ? current.zoom
+        : [current.zoom, current.zoom];
+      const xMoved =
+        previous !== null &&
+        (currentZoom[0] !== previous.zoom[0] ||
+          current.target[0] !== previous.target[0]);
+      const yMoved =
+        previous !== null &&
+        (currentZoom[1] !== previous.zoom[1] ||
+          current.target[1] !== previous.target[1]);
 
       const mainWidth = settings.treenomeEnabled
         ? (deckSize.width * MAIN_WIDTH_WITH_TREENOME) / 100
         : deckSize.width;
-      const target: [number, number] = [
+      const fittedTarget: [number, number] = [
         (xRange.min + xRange.robust_max) / 2,
         (yRange.min + yRange.max) / 2,
       ];
-      fittedView.current = {
+      const nextFittedView = {
         zoom: [
           zoomToFit(mainWidth, xSpan, X_FILL_FRACTION),
           zoomToFit(deckSize.height, ySpan, Y_FILL_FRACTION),
-        ],
-        target,
+        ] as [number, number],
+        target: fittedTarget,
       };
+      fittedView.current = nextFittedView;
       minimapViewState.current = {
         zoom: [
           zoomToFit(
             (deckSize.width * MINIMAP_WIDTH) / 100,
             xSpan,
-            X_FILL_FRACTION
+            X_FILL_FRACTION,
           ),
           zoomToFit(
             (deckSize.height * MINIMAP_HEIGHT) / 100,
             ySpan,
-            Y_FILL_FRACTION
+            Y_FILL_FRACTION,
           ),
         ],
-        target,
+        target: fittedTarget,
       };
 
-      // Routed through onViewStateChange so that the views that follow the
-      // main one (the minimap, and the treenome browser's rows) are brought
-      // along with it.
-      onViewStateChange({
-        viewId: "main",
-        interactionState: {},
-        viewState: { ...current, ...fittedView.current },
-      });
+      const applyX = x === "force" || (x === "if-unmoved" && !xMoved);
+      const applyY = y === "force" || (y === "if-unmoved" && !yMoved);
+      if (applyX || applyY) {
+        setViewState(
+          withDependentViews({
+            ...current,
+            zoom: [
+              applyX ? nextFittedView.zoom[0] : currentZoom[0],
+              applyY ? nextFittedView.zoom[1] : currentZoom[1],
+            ],
+            target: [
+              applyX ? nextFittedView.target[0] : current.target[0],
+              applyY ? nextFittedView.target[1] : current.target[1],
+            ],
+          }),
+        );
+      }
+      return true;
     },
-    [deckSize, settings.treenomeEnabled, onViewStateChange]
+    [
+      deckSize?.height,
+      deckSize?.width,
+      settings.treenomeEnabled,
+      withDependentViews,
+    ],
   );
 
   const zoomReset = useCallback(() => {
-    setViewState({
-      ...defaultViewState,
-      ...fittedView.current,
-      minimap: minimapViewState.current,
-    });
-  }, []);
+    setViewState(
+      withDependentViews({
+        ...defaultViewState,
+        ...fittedView.current,
+      }),
+    );
+  }, [withDependentViews]);
 
   return {
     viewState,
@@ -298,8 +324,8 @@ export interface View {
   fitToRanges: (
     xRange: XRange,
     yRange: YRange,
-    options?: { onlyIfUnmoved?: boolean }
-  ) => void;
+    options?: { x?: FitMode; y?: FitMode },
+  ) => boolean;
   xzoom: number;
   mouseXY: number[];
   setMouseXY: React.Dispatch<React.SetStateAction<number[]>>;

--- a/taxonium_component/src/hooks/useView.tsx
+++ b/taxonium_component/src/hooks/useView.tsx
@@ -1,9 +1,9 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import { OrthographicView, OrthographicController } from "@deck.gl/core";
 import type { OrthographicViewProps } from "@deck.gl/core";
 import type { Settings } from "../types/settings";
 import type { DeckSize } from "../types/common";
-import type { ViewState } from "../types/view";
+import type { SubViewState, ViewState } from "../types/view";
 
 interface ViewStateChangeParameters<ViewStateT> {
   viewId: string;
@@ -18,12 +18,30 @@ interface StyledViewProps extends OrthographicViewProps {
 
 const identityMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
+// Fractions of the deck that each view occupies. These must match the
+// OrthographicView definitions below.
+const MINIMAP_WIDTH_FRACTION = 0.2;
+const MINIMAP_HEIGHT_FRACTION = 0.35;
+const MAIN_WIDTH_FRACTION_WITH_TREENOME = 0.4;
+
+// Proportion of the fitted range left as blank space at each edge.
+const FIT_MARGIN = 0.02;
+
+const defaultMinimapViewState: SubViewState = {
+  zoom: -3,
+  target: [250, 1000],
+};
+
+// Zoom level at which a range of `span` world units fills `pixels` pixels.
+const zoomToFit = (pixels: number, span: number) =>
+  Math.log2(pixels / (span * (1 + 2 * FIT_MARGIN)));
+
 const defaultViewState: ViewState = {
   zoom: [0, -2],
   target: [window.screen.width < 600 ? 500 : 1400, 1000],
   pitch: 0,
   bearing: 0,
-  minimap: { zoom: -3, target: [250, 1000] }
+  minimap: defaultMinimapViewState,
 };
 
 type ViewStateType = ViewState;
@@ -38,6 +56,24 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
   const [viewState, setViewState] = useState<ViewStateType>(defaultViewState);
   const [mouseXY, setMouseXY] = useState([0, 0]);
   const [zoomAxis, setZoomAxis] = useState("Y");
+
+  // The minimap always shows the whole tree, so its view state is not the
+  // user's to change. It is kept in a ref because onViewStateChange has to
+  // reapply it on every interaction without being re-created each time.
+  const minimapViewState = useRef<SubViewState>(defaultMinimapViewState);
+
+  // The current view state, readable from callbacks that must not depend on
+  // it (a dependency on it would re-create them on every pan and zoom).
+  const viewStateRef = useRef<ViewStateType>(viewState);
+  viewStateRef.current = viewState;
+
+  // What the tree was last fitted to, so that resetting the zoom goes back to
+  // the whole tree rather than to a hardcoded guess.
+  const fittedView = useRef<{
+    xZoom: number;
+    xTarget: number;
+    yTarget: number | null;
+  } | null>(null);
 
   const baseViewState = useMemo(() => ({ ...viewState }), [viewState]);
 
@@ -109,7 +145,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
         return false;
       }
 
-      newViewState.minimap = { zoom: -3, target: [250, 1000] };
+      newViewState.minimap = minimapViewState.current;
       newViewState["browser-main"] = {
         zoom: [
           -3,
@@ -144,8 +180,90 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
     [zoomAxis]
   );
 
+  // Fit the x axis (and the minimap, which shows both axes) to the extent of
+  // the tree. x coordinates have no fixed scale -- they are branch lengths in
+  // whatever units the tree was built with -- so the only way to know how far
+  // to zoom out is to be told the range the data covers.
+  //
+  // With onlyIfUnmoved the fit is abandoned if the x axis is no longer where
+  // the last fit left it, i.e. if the user has panned or zoomed it themselves.
+  const fitToRanges = useCallback(
+    (
+      xRange: { min: number; robust_max: number },
+      yRange?: { min: number; max: number },
+      { onlyIfUnmoved = false }: { onlyIfUnmoved?: boolean } = {}
+    ) => {
+      if (!deckSize || !deckSize.width || isNaN(deckSize.width)) {
+        return;
+      }
+      const xSpan = xRange.robust_max - xRange.min;
+      if (!(xSpan > 0)) {
+        return;
+      }
+      const xCentre = (xRange.min + xRange.robust_max) / 2;
+      const mainWidth = settings.treenomeEnabled
+        ? deckSize.width * MAIN_WIDTH_FRACTION_WITH_TREENOME
+        : deckSize.width;
+      const xZoom = zoomToFit(mainWidth, xSpan);
+
+      const ySpan = yRange ? yRange.max - yRange.min : 0;
+      const yCentre = yRange ? (yRange.min + yRange.max) / 2 : null;
+      const minimap: SubViewState =
+        ySpan > 0 && yCentre !== null
+          ? {
+              zoom: [
+                zoomToFit(deckSize.width * MINIMAP_WIDTH_FRACTION, xSpan),
+                zoomToFit(deckSize.height * MINIMAP_HEIGHT_FRACTION, ySpan),
+              ] as [number, number],
+              target: [xCentre, yCentre] as [number, number],
+            }
+          : minimapViewState.current;
+
+      // Deliberately checked before setViewState rather than inside its
+      // updater: the updater has to stay pure, and it can be run twice.
+      const previous = fittedView.current;
+      const current = viewStateRef.current;
+      if (
+        onlyIfUnmoved &&
+        previous &&
+        ((current.zoom as [number, number])[0] !== previous.xZoom ||
+          current.target[0] !== previous.xTarget)
+      ) {
+        return;
+      }
+
+      fittedView.current = { xZoom, xTarget: xCentre, yTarget: yCentre };
+      minimapViewState.current = minimap;
+
+      setViewState(
+        (vs: ViewStateType) =>
+          ({
+            ...vs,
+            zoom: [xZoom, (vs.zoom as [number, number])[1]] as [number, number],
+            target: [xCentre, vs.target[1]] as [number, number],
+            minimap,
+          }) as ViewStateType
+      );
+    },
+    [deckSize, settings.treenomeEnabled]
+  );
+
   const zoomReset = useCallback(() => {
-    setViewState(defaultViewState);
+    const reset: ViewStateType = {
+      ...defaultViewState,
+      minimap: minimapViewState.current,
+    };
+    if (fittedView.current) {
+      reset.zoom = [
+        fittedView.current.xZoom,
+        (defaultViewState.zoom as [number, number])[1],
+      ];
+      reset.target = [
+        fittedView.current.xTarget,
+        fittedView.current.yTarget ?? defaultViewState.target[1],
+      ] as [number, number];
+    }
+    setViewState(reset);
   }, []);
 
   return {
@@ -157,6 +275,7 @@ const useView = ({ settings, deckSize, mouseDownIsMinimap }: UseViewProps) => {
     setZoomAxis,
     modelMatrix: identityMatrix,
     zoomIncrement,
+    fitToRanges,
     xzoom: 0,
     mouseXY,
     setMouseXY,
@@ -176,6 +295,11 @@ export interface View {
   setZoomAxis: React.Dispatch<React.SetStateAction<string>>;
   modelMatrix: number[];
   zoomIncrement: (increment: number, axis?: string) => void;
+  fitToRanges: (
+    xRange: { min: number; robust_max: number },
+    yRange?: { min: number; max: number },
+    options?: { onlyIfUnmoved?: boolean }
+  ) => void;
   xzoom: number;
   mouseXY: number[];
   setMouseXY: React.Dispatch<React.SetStateAction<number[]>>;

--- a/taxonium_component/src/types/backend.ts
+++ b/taxonium_component/src/types/backend.ts
@@ -26,6 +26,16 @@ export interface NodesResponse {
   [key: string]: unknown;
 }
 
+/**
+ * The extent of one x accessor over the whole tree. `robust_max` excludes
+ * extreme long-branch outliers and is what the initial view is fitted to.
+ */
+export interface XRange {
+  min: number;
+  max: number;
+  robust_max: number;
+}
+
 export interface Config {
   title?: string;
   source?: string;
@@ -33,6 +43,10 @@ export interface Config {
   initial_x?: number;
   initial_y?: number;
   initial_zoom?: number;
+  /** x extents keyed by accessor ("x_dist", "x_time"). */
+  x_ranges?: Record<string, XRange>;
+  y_range?: { min: number; max: number };
+  x_accessors?: string[];
   /**
    * When {@link useHydratedMutations} is false this array contains indices into
    * the {@link mutations} array. When true it contains {@link Mutation}

--- a/taxonium_component/src/types/backend.ts
+++ b/taxonium_component/src/types/backend.ts
@@ -48,7 +48,6 @@ export interface Config {
   initial_x?: number;
   initial_y?: number;
   initial_zoom?: number;
-  /** x extents keyed by accessor ("x_dist", "x_time"). */
   x_ranges?: Record<string, XRange>;
   y_range?: YRange;
   x_accessors?: string[];

--- a/taxonium_component/src/types/backend.ts
+++ b/taxonium_component/src/types/backend.ts
@@ -36,6 +36,11 @@ export interface XRange {
   robust_max: number;
 }
 
+export interface YRange {
+  min: number;
+  max: number;
+}
+
 export interface Config {
   title?: string;
   source?: string;
@@ -45,7 +50,7 @@ export interface Config {
   initial_zoom?: number;
   /** x extents keyed by accessor ("x_dist", "x_time"). */
   x_ranges?: Record<string, XRange>;
-  y_range?: { min: number; max: number };
+  y_range?: YRange;
   x_accessors?: string[];
   /**
    * When {@link useHydratedMutations} is false this array contains indices into

--- a/taxonium_component/src/utils/initialViewConfig.test.js
+++ b/taxonium_component/src/utils/initialViewConfig.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateConfig,
+  getInitialViewConfig,
+} from "../../../taxonium_data_handling/importing.js";
+
+describe("getInitialViewConfig", () => {
+  it("uses the full extent when there are no substantial outliers", () => {
+    const nodes = Array.from({ length: 100 }, (_, x_dist) => ({
+      x_dist,
+      x_time: 2000 + x_dist / 10,
+    }));
+
+    const result = getInitialViewConfig(nodes, { minY: 0, maxY: 2400 });
+
+    expect(result.x_ranges.x_dist).toEqual({
+      min: 0,
+      max: 99,
+      robust_max: 99,
+    });
+    expect(result.x_ranges.x_time).toEqual({
+      min: 2000,
+      max: 2009.9,
+      robust_max: 2009.9,
+    });
+    expect(result.initial_x).toBe(49.5);
+    expect(result.initial_y).toBe(1200);
+  });
+
+  it("trims a small group of long-branch outliers", () => {
+    const bulk = Array.from({ length: 990 }, (_, index) => ({
+      x_dist: (index / 989) * 200,
+    }));
+    const outliers = Array.from({ length: 10 }, (_, index) => ({
+      x_dist: 1000 - index,
+    }));
+
+    const range = getInitialViewConfig([...bulk, ...outliers], {
+      minY: 0,
+      maxY: 2400,
+    }).x_ranges.x_dist;
+
+    expect(range.min).toBe(0);
+    expect(range.max).toBe(1000);
+    expect(range.robust_max).toBeGreaterThan(250);
+    expect(range.robust_max).toBeLessThan(270);
+  });
+
+  it("keeps the full range when trimming would leave a negligible span", () => {
+    const nodes = [
+      ...Array.from({ length: 99 }, () => ({ x_dist: 0 })),
+      { x_dist: 1000 },
+    ];
+
+    expect(
+      getInitialViewConfig(nodes, { minY: 4, maxY: 4 }).x_ranges.x_dist,
+    ).toEqual({ min: 0, max: 1000, robust_max: 1000 });
+  });
+
+  it("ignores non-finite coordinates", () => {
+    const nodes = [
+      { x_dist: NaN },
+      { x_dist: Infinity },
+      { x_dist: 2 },
+      { x_dist: 4 },
+    ];
+
+    expect(
+      getInitialViewConfig(nodes, { minY: 0, maxY: 1 }).x_ranges.x_dist,
+    ).toEqual({ min: 2, max: 4, robust_max: 4 });
+  });
+
+  it("reuses a precomputed view when generating config", () => {
+    const initial_view = {
+      x_ranges: { x_dist: { min: 0, max: 10, robust_max: 8 } },
+      y_range: { min: 0, max: 20 },
+      initial_x: 4,
+      initial_y: 10,
+    };
+    const config = {};
+
+    generateConfig(config, {
+      nodes: [{ name: "root", node_id: 0, parent_id: 0, x_dist: 100 }],
+      mutations: [],
+      rootMutations: [],
+      rootId: 0,
+      initial_view,
+    });
+
+    expect(config.x_ranges).toBe(initial_view.x_ranges);
+  });
+});

--- a/taxonium_component/src/webworkers/localBackendWorker.js
+++ b/taxonium_component/src/webworkers/localBackendWorker.js
@@ -58,12 +58,10 @@ const waitForProcessedData = async () => {
   }
 };
 
-// Bounds may be absent or only partly filled in, which means "the whole
-// tree": that is how the overview data behind the minimap is requested.
-export const queryNodes = async (suppliedBounds) => {
+// Bounds that are only partly filled in mean "the whole tree": that is how
+// the overview data behind the minimap is requested.
+export const queryNodes = async (boundsForQueries = {}) => {
   await waitForProcessedData();
-
-  const boundsForQueries = suppliedBounds ? suppliedBounds : {};
 
   const {
     nodes,

--- a/taxonium_component/src/webworkers/localBackendWorker.js
+++ b/taxonium_component/src/webworkers/localBackendWorker.js
@@ -58,8 +58,7 @@ const waitForProcessedData = async () => {
   }
 };
 
-// Bounds that are only partly filled in mean "the whole tree": that is how
-// the overview data behind the minimap is requested.
+// Partial bounds request the whole tree for the minimap.
 export const queryNodes = async (boundsForQueries = {}) => {
   await waitForProcessedData();
 

--- a/taxonium_component/src/webworkers/localBackendWorker.js
+++ b/taxonium_component/src/webworkers/localBackendWorker.js
@@ -58,8 +58,12 @@ const waitForProcessedData = async () => {
   }
 };
 
-export const queryNodes = async (boundsForQueries) => {
+// Bounds may be absent or only partly filled in, which means "the whole
+// tree": that is how the overview data behind the minimap is requested.
+export const queryNodes = async (suppliedBounds) => {
   await waitForProcessedData();
+
+  const boundsForQueries = suppliedBounds ? suppliedBounds : {};
 
   const {
     nodes,
@@ -99,7 +103,7 @@ export const queryNodes = async (boundsForQueries) => {
       max_y,
       min_x,
       max_x,
-      boundsForQueries.xType
+      boundsForQueries.xType ? boundsForQueries.xType : "x_dist"
     ),
   };
 

--- a/taxonium_component/vitest.config.js
+++ b/taxonium_component/vitest.config.js
@@ -1,85 +1,35 @@
-// vitest.config.js
 import { defineConfig, mergeConfig } from "vitest/config";
-import viteConfig from "./vite.config.js"; // Your existing Vite configuration
+import viteConfig from "./vite.config.js";
 
 export default mergeConfig(
-  viteConfig, // Inherits plugins (React, TailwindCSS, etc.) and resolve.alias from your main Vite config
+  viteConfig,
   defineConfig({
     test: {
-      /**
-       * Enable global APIs (describe, test, expect, etc.)
-       * @see https://vitest.dev/config/#globals
-       */
-      globals: true,
-      /**
-       * JSDOM is a good default for testing React components that interact with the DOM.
-       * @see https://vitest.dev/config/#environment
-       */
       environment: "jsdom",
-      /**
-       * A setup file to run before each test file.
-       * Ideal for configuring @testing-library/jest-dom or other global test utilities.
-       * @see https://vitest.dev/config/#setupfiles
-       */
-      setupFiles: "./vitest.setup.js", // Or './src/setupTests.js' if you prefer
-      /**
-       * Include patterns for test files.
-       * @see https://vitest.dev/config/#include
-       */
-      include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-      /**
-       * Exclude patterns for test files.
-       * This prevents running tests on Storybook stories files themselves unless they are explicitly tests.
-       * @see https://vitest.dev/config/#exclude
-       */
-      exclude: [
-        "**/node_modules/**",
-        "**/dist/**",
-        "**/.{idea,git,cache,output,temp}/**",
-        "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,playwright,protractor}.config.*",
-        "**/*.stories.@(js|jsx|ts|tsx|mdx)", // Exclude story files if they are not tests
-      ],
-      /**
-       * Coverage configuration.
-       * @see https://vitest.dev/config/#coverage
-       */
+      setupFiles: "./vitest.setup.js",
       coverage: {
-        provider: "v8", // or 'istanbul'
+        provider: "v8",
         reporter: ["text", "json-summary", "html"],
         reportsDirectory: "./coverage",
-        include: ["src/**/*.{js,jsx,ts,tsx}"], // Files to include in coverage
+        include: ["src/**/*.{js,jsx,ts,tsx}"],
         exclude: [
-          // Default Vitest exclusions
           "**/node_modules/**",
           "**/dist/**",
           "**/cypress/**",
           "**/.{idea,git,cache,output,temp}/**",
           "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,playwright,protractor}.config.*",
-          // Storybook specific
           "**/*.stories.*",
           "**/*.story.*",
-          // Test setup files
-          "vitest.setup.js", // or your setup file path
+          "vitest.setup.js",
           "src/setupTests.js",
-          // Typings
           "src/**/*.d.ts",
           "src/**/vite-env.d.ts",
-          // Entry points or config files not usually covered
-          "src/main.{js,jsx,ts,tsx}", // Adjust if your entry point is different
-          "src/App.{js,jsx,ts,tsx}", // Adjust if this is your root App component
-          "src/index.js", // Your library entry point
-          // Add any other files or patterns to exclude
+          "src/main.{js,jsx,ts,tsx}",
+          "src/App.{js,jsx,ts,tsx}",
+          "src/index.js",
         ],
-        all: true, // Set to true to include all files in `include` in the report, even if not tested
+        all: true,
       },
-      // CSS processing is typically handled by Vite plugins (like tailwindcss, cssInjectedByJsPlugin)
-      // which are inherited from your main vite.config.js.
-      // If you encounter issues, you might need specific css configurations here.
-      // css: true, // or an object for specific CSS processing options
     },
-    // The `build` configuration from your `vite.config.js` is for your library build
-    // and should generally not affect Vitest. `mergeConfig` should handle this,
-    // but if you face issues, you can explicitly unset it for tests:
-    // build: undefined,
-  })
+  }),
 );

--- a/taxonium_component/vitest.setup.js
+++ b/taxonium_component/vitest.setup.js
@@ -1,0 +1,2 @@
+// React needs this to be set before act() is used outside a test renderer.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;

--- a/taxonium_data_handling/importing.js
+++ b/taxonium_data_handling/importing.js
@@ -126,31 +126,21 @@ const X_ROBUST_MIN_FRACTION = 0.15;
 const QUANTILE_BINS = 4096;
 
 // Histogram-based quantile so that we never have to sort (or copy) a list of
-// x positions that can have tens of millions of entries. The value returned is
-// the top of the bin the quantile falls in, so it is a slight over-estimate.
+// x positions that can have tens of millions of entries. Assumes max > min
+// and at least one finite value. The value returned is the top of the bin the
+// quantile falls in, so it is a slight over-estimate.
 const approximateQuantile = (nodes, accessor, min, max, quantile) => {
-  if (!(max > min)) {
-    return max;
-  }
   const counts = new Int32Array(QUANTILE_BINS);
   const scale = QUANTILE_BINS / (max - min);
   let total = 0;
   for (const node of nodes) {
     const value = node[accessor];
-    if (typeof value !== "number" || !isFinite(value)) {
+    if (!Number.isFinite(value)) {
       continue;
     }
-    let bin = Math.floor((value - min) * scale);
-    if (bin < 0) {
-      bin = 0;
-    } else if (bin >= QUANTILE_BINS) {
-      bin = QUANTILE_BINS - 1;
-    }
+    const bin = Math.min(Math.floor((value - min) * scale), QUANTILE_BINS - 1);
     counts[bin]++;
     total++;
-  }
-  if (total === 0) {
-    return max;
   }
   const target = quantile * total;
   let cumulative = 0;
@@ -163,8 +153,7 @@ const approximateQuantile = (nodes, accessor, min, max, quantile) => {
   return max;
 };
 
-// Which x accessors the nodes actually carry.
-export const getXAccessors = (nodes) => {
+const getXAccessors = (nodes) => {
   const firstNode = nodes && nodes.length ? nodes[0] : null;
   const accessors = [];
   if (firstNode && firstNode.x_dist !== undefined) {
@@ -178,18 +167,12 @@ export const getXAccessors = (nodes) => {
   return accessors.length ? accessors : ["x_time"];
 };
 
-// { min, max, robust_max } for one x accessor, or null if the nodes don't
-// have usable values for it.
-export const getXRange = (nodes, accessor) => {
-  if (!nodes || !nodes.length) {
-    return null;
-  }
+const getXRange = (nodes, accessor) => {
   let min = Infinity;
   let max = -Infinity;
-  let count = 0;
   for (const node of nodes) {
     const value = node[accessor];
-    if (typeof value !== "number" || !isFinite(value)) {
+    if (!Number.isFinite(value)) {
       continue;
     }
     if (value < min) {
@@ -198,10 +181,12 @@ export const getXRange = (nodes, accessor) => {
     if (value > max) {
       max = value;
     }
-    count++;
   }
-  if (count === 0) {
+  if (min === Infinity) {
     return null;
+  }
+  if (min === max) {
+    return { min, max, robust_max: max };
   }
   const quantile = approximateQuantile(
     nodes,
@@ -210,37 +195,29 @@ export const getXRange = (nodes, accessor) => {
     max,
     X_ROBUST_QUANTILE
   );
-  let robustMax = min + (quantile - min) * X_ROBUST_HEADROOM;
-  if (robustMax < min + (max - min) * X_ROBUST_MIN_FRACTION) {
-    robustMax = max;
-  }
-  if (robustMax > max) {
-    robustMax = max;
-  }
-  return { min, max, robust_max: robustMax };
+  const robustMax = min + (quantile - min) * X_ROBUST_HEADROOM;
+  const tooNarrow = robustMax < min + (max - min) * X_ROBUST_MIN_FRACTION;
+  return {
+    min,
+    max,
+    robust_max: tooNarrow || robustMax > max ? max : robustMax,
+  };
 };
 
-export const getXRanges = (nodes, accessors) => {
-  const ranges = {};
-  for (const accessor of accessors ? accessors : getXAccessors(nodes)) {
-    const range = getXRange(nodes, accessor);
-    if (range) {
-      ranges[accessor] = range;
-    }
-  }
-  return ranges;
-};
-
-// Everything the client needs in order to pick a sensible starting view.
 // initial_x / initial_y stay for backwards compatibility with clients that
 // only know about a centre point; x_ranges and y_range let a newer client
 // also work out how far to zoom out.
 export const getInitialViewConfig = (nodes, { minY, maxY }) => {
   const x_accessors = getXAccessors(nodes);
-  const x_ranges = getXRanges(nodes, x_accessors);
+  const x_ranges = {};
+  for (const accessor of x_accessors) {
+    const range = getXRange(nodes, accessor);
+    if (range) {
+      x_ranges[accessor] = range;
+    }
+  }
   const primaryRange = x_ranges[x_accessors[0]];
   const initialView = {
-    x_accessors,
     x_ranges,
     y_range: { min: minY, max: maxY },
     initial_y: (minY + maxY) / 2,
@@ -599,11 +576,4 @@ export const generateConfig = (config, processedUploadedData) => {
     : colorByOptions[0];
 };
 
-export default {
-  processJsonl,
-  generateConfig,
-  getXAccessors,
-  getXRange,
-  getXRanges,
-  getInitialViewConfig,
-};
+export default { processJsonl, generateConfig, getInitialViewConfig };

--- a/taxonium_data_handling/importing.js
+++ b/taxonium_data_handling/importing.js
@@ -111,6 +111,146 @@ function reduceMaxOrMin(array, accessFunction, maxOrMin) {
   }
 }
 
+// A handful of very divergent sequences (e.g. ones with many spurious
+// mutations) can make the x extent of a tree several times wider than the
+// part of it that anyone wants to look at. The initial view is therefore
+// fitted to a "robust" x range: the X_ROBUST_QUANTILE quantile of node x
+// positions, with some headroom, capped at the true maximum. For a tree
+// without such outliers this is just the true maximum.
+const X_ROBUST_QUANTILE = 0.99;
+const X_ROBUST_HEADROOM = 1.3;
+// If the robust range would be narrower than this fraction of the full range
+// there is no bulk worth zooming in on (e.g. nearly every node sits at the
+// same x), so the full range is used instead.
+const X_ROBUST_MIN_FRACTION = 0.15;
+const QUANTILE_BINS = 4096;
+
+// Histogram-based quantile so that we never have to sort (or copy) a list of
+// x positions that can have tens of millions of entries. The value returned is
+// the top of the bin the quantile falls in, so it is a slight over-estimate.
+const approximateQuantile = (nodes, accessor, min, max, quantile) => {
+  if (!(max > min)) {
+    return max;
+  }
+  const counts = new Int32Array(QUANTILE_BINS);
+  const scale = QUANTILE_BINS / (max - min);
+  let total = 0;
+  for (const node of nodes) {
+    const value = node[accessor];
+    if (typeof value !== "number" || !isFinite(value)) {
+      continue;
+    }
+    let bin = Math.floor((value - min) * scale);
+    if (bin < 0) {
+      bin = 0;
+    } else if (bin >= QUANTILE_BINS) {
+      bin = QUANTILE_BINS - 1;
+    }
+    counts[bin]++;
+    total++;
+  }
+  if (total === 0) {
+    return max;
+  }
+  const target = quantile * total;
+  let cumulative = 0;
+  for (let bin = 0; bin < QUANTILE_BINS; bin++) {
+    cumulative += counts[bin];
+    if (cumulative >= target) {
+      return min + ((bin + 1) / QUANTILE_BINS) * (max - min);
+    }
+  }
+  return max;
+};
+
+// Which x accessors the nodes actually carry.
+export const getXAccessors = (nodes) => {
+  const firstNode = nodes && nodes.length ? nodes[0] : null;
+  const accessors = [];
+  if (firstNode && firstNode.x_dist !== undefined) {
+    accessors.push("x_dist");
+  }
+  if (firstNode && firstNode.x_time !== undefined) {
+    accessors.push("x_time");
+  }
+  // A tree with neither is treated as a time tree, which is what the client
+  // falls back to when there are no distances.
+  return accessors.length ? accessors : ["x_time"];
+};
+
+// { min, max, robust_max } for one x accessor, or null if the nodes don't
+// have usable values for it.
+export const getXRange = (nodes, accessor) => {
+  if (!nodes || !nodes.length) {
+    return null;
+  }
+  let min = Infinity;
+  let max = -Infinity;
+  let count = 0;
+  for (const node of nodes) {
+    const value = node[accessor];
+    if (typeof value !== "number" || !isFinite(value)) {
+      continue;
+    }
+    if (value < min) {
+      min = value;
+    }
+    if (value > max) {
+      max = value;
+    }
+    count++;
+  }
+  if (count === 0) {
+    return null;
+  }
+  const quantile = approximateQuantile(
+    nodes,
+    accessor,
+    min,
+    max,
+    X_ROBUST_QUANTILE
+  );
+  let robustMax = min + (quantile - min) * X_ROBUST_HEADROOM;
+  if (robustMax < min + (max - min) * X_ROBUST_MIN_FRACTION) {
+    robustMax = max;
+  }
+  if (robustMax > max) {
+    robustMax = max;
+  }
+  return { min, max, robust_max: robustMax };
+};
+
+export const getXRanges = (nodes, accessors) => {
+  const ranges = {};
+  for (const accessor of accessors ? accessors : getXAccessors(nodes)) {
+    const range = getXRange(nodes, accessor);
+    if (range) {
+      ranges[accessor] = range;
+    }
+  }
+  return ranges;
+};
+
+// Everything the client needs in order to pick a sensible starting view.
+// initial_x / initial_y stay for backwards compatibility with clients that
+// only know about a centre point; x_ranges and y_range let a newer client
+// also work out how far to zoom out.
+export const getInitialViewConfig = (nodes, { minY, maxY }) => {
+  const x_accessors = getXAccessors(nodes);
+  const x_ranges = getXRanges(nodes, x_accessors);
+  const primaryRange = x_ranges[x_accessors[0]];
+  const initialView = {
+    x_accessors,
+    x_ranges,
+    y_range: { min: minY, max: maxY },
+    initial_y: (minY + maxY) / 2,
+  };
+  if (primaryRange) {
+    initialView.initial_x = (primaryRange.min + primaryRange.robust_max) / 2;
+  }
+  return initialView;
+};
+
 export const setUpStream = (
   the_stream,
   data,
@@ -324,10 +464,13 @@ export const processJsonl = async (
 
 export const generateConfig = (config, processedUploadedData) => {
   config.num_nodes = processedUploadedData.nodes.length;
-  config.initial_x =
-    (processedUploadedData.overallMaxX + processedUploadedData.overallMinX) / 2;
-  config.initial_y =
-    (processedUploadedData.overallMaxY + processedUploadedData.overallMinY) / 2;
+  Object.assign(
+    config,
+    getInitialViewConfig(processedUploadedData.nodes, {
+      minY: processedUploadedData.overallMinY,
+      maxY: processedUploadedData.overallMaxY,
+    })
+  );
   config.initial_zoom = config.initial_zoom ? config.initial_zoom : -2;
   config.genes = [
     ...new Set(processedUploadedData.mutations.map((x) => (x ? x.gene : null))),
@@ -354,14 +497,7 @@ export const generateConfig = (config, processedUploadedData) => {
     "is_tip",
   ];
 
-  const firstNode = processedUploadedData.nodes[0];
-
-  config.x_accessors =
-    firstNode.x_dist !== undefined && firstNode.x_time !== undefined
-      ? ["x_dist", "x_time"]
-      : firstNode.x_dist
-      ? ["x_dist"]
-      : ["x_time"];
+  config.x_accessors = getXAccessors(processedUploadedData.nodes);
 
   config.keys_to_display = Object.keys(processedUploadedData.nodes[0]).filter(
     (x) => !to_remove.includes(x)
@@ -463,4 +599,11 @@ export const generateConfig = (config, processedUploadedData) => {
     : colorByOptions[0];
 };
 
-export default { processJsonl, generateConfig };
+export default {
+  processJsonl,
+  generateConfig,
+  getXAccessors,
+  getXRange,
+  getXRanges,
+  getInitialViewConfig,
+};

--- a/taxonium_data_handling/importing.js
+++ b/taxonium_data_handling/importing.js
@@ -111,24 +111,14 @@ function reduceMaxOrMin(array, accessFunction, maxOrMin) {
   }
 }
 
-// A handful of very divergent sequences (e.g. ones with many spurious
-// mutations) can make the x extent of a tree several times wider than the
-// part of it that anyone wants to look at. The initial view is therefore
-// fitted to a "robust" x range: the X_ROBUST_QUANTILE quantile of node x
-// positions, with some headroom, capped at the true maximum. For a tree
-// without such outliers this is just the true maximum.
+// Fit to the bulk of the tree so that a few divergent sequences do not leave
+// the useful region off screen.
 const X_ROBUST_QUANTILE = 0.99;
 const X_ROBUST_HEADROOM = 1.3;
-// If the robust range would be narrower than this fraction of the full range
-// there is no bulk worth zooming in on (e.g. nearly every node sits at the
-// same x), so the full range is used instead.
 const X_ROBUST_MIN_FRACTION = 0.15;
 const QUANTILE_BINS = 4096;
 
-// Histogram-based quantile so that we never have to sort (or copy) a list of
-// x positions that can have tens of millions of entries. Assumes max > min
-// and at least one finite value. The value returned is the top of the bin the
-// quantile falls in, so it is a slight over-estimate.
+// Avoid sorting or copying node coordinates, which can number in the millions.
 const approximateQuantile = (nodes, accessor, min, max, quantile) => {
   const counts = new Int32Array(QUANTILE_BINS);
   const scale = QUANTILE_BINS / (max - min);
@@ -162,8 +152,6 @@ const getXAccessors = (nodes) => {
   if (firstNode && firstNode.x_time !== undefined) {
     accessors.push("x_time");
   }
-  // A tree with neither is treated as a time tree, which is what the client
-  // falls back to when there are no distances.
   return accessors.length ? accessors : ["x_time"];
 };
 
@@ -443,10 +431,11 @@ export const generateConfig = (config, processedUploadedData) => {
   config.num_nodes = processedUploadedData.nodes.length;
   Object.assign(
     config,
-    getInitialViewConfig(processedUploadedData.nodes, {
-      minY: processedUploadedData.overallMinY,
-      maxY: processedUploadedData.overallMaxY,
-    })
+    processedUploadedData.initial_view ??
+      getInitialViewConfig(processedUploadedData.nodes, {
+        minY: processedUploadedData.overallMinY,
+        maxY: processedUploadedData.overallMaxY,
+      })
   );
   config.initial_zoom = config.initial_zoom ? config.initial_zoom : -2;
   config.genes = [


### PR DESCRIPTION
The starting view used a hardcoded x zoom of 0, i.e. one world unit per pixel, and centred x on the midpoint of the tree's full x range. Both assumptions only hold for trees whose x coordinates happen to be scaled the way taxoniumtools scales them, and even then only on a desktop-width window.

For a viral_usher tree such as
taxonium.org/viral-usher/dengue_virus_type_1/NC_001477.1 a handful of very divergent sequences stretch the x range to 2805 while 99% of the tree sits below 620. The midpoint of the full range, 1402, is therefore empty space, and the tree loaded off screen: only one node fell inside the default viewport. Narrow windows were badly zoomed in for the same reason.

The data layer now reports the x extent of the tree per x accessor (x_ranges) plus the y extent (y_range), where the x extent carries a robust maximum that ignores extreme long-branch outliers. The client fits the x zoom and target to that range and the current viewport width, so the tree fills the window whatever units its branch lengths are in. The minimap, which was also pinned to hardcoded numbers, is fitted to the same extents, and resetting the zoom now returns to the fitted view rather than to the old guess.

The fit is redone when the x axis switches between distance and time (their scales are unrelated), when the treenome browser opens or closes, and on resize while the user has not panned or zoomed x themselves. Clients talking to a backend that does not report x_ranges keep the previous behaviour.