### PR TITLE
Speed up zoomed-in viewport queries on large trees

### DIFF
--- a/taxonium_component/src/utils/filtering.test.js
+++ b/taxonium_component/src/utils/filtering.test.js
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import filtering from "../../../taxonium_data_handling/filtering.js";
+
+// A balanced tree in Y order, with the root in the middle of the array.
+function balancedTree(depth) {
+  const root = 2 ** (depth - 1);
+  return Array.from({ length: 2 ** depth - 1 }, (_, node_id) => {
+    const position = node_id + 1;
+    const span = position & -position;
+    const parent =
+      position === root
+        ? position
+        : position & (span * 2)
+          ? position - span
+          : position + span;
+    return {
+      node_id,
+      parent_id: parent - 1,
+      y: node_id,
+      x_dist: depth - 1 - Math.log2(span),
+      x_time: 2000 + depth - 1 - Math.log2(span),
+      num_tips: span,
+      mutations: [0],
+    };
+  });
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("addParents", () => {
+  it("returns shared ancestors once in data order for an unordered selection", () => {
+    const nodes = balancedTree(7);
+    const selected = [nodes[10], nodes[0], nodes[10], nodes[7]];
+    const originalOrder = [...selected];
+    const result = filtering.addParents(nodes, selected);
+
+    expect(result.map((node) => node.node_id)).toEqual([
+      0, 1, 3, 7, 9, 10, 11, 15, 31, 63,
+    ]);
+    result.forEach((node) => expect(node).toBe(nodes[node.node_id]));
+    expect(selected).toEqual(originalOrder);
+    expect(nodes.map((node) => node.node_id)).toEqual(
+      Array.from({ length: nodes.length }, (_, i) => i),
+    );
+  });
+
+  it("preserves the complete tree for a dense selection", () => {
+    const nodes = balancedTree(7);
+    const tips = nodes.filter((node) => node.num_tips === 1).reverse();
+
+    expect(filtering.addParents(nodes, tips)).toEqual(nodes);
+  });
+
+  it("handles an empty selection, an empty tree, and a root-only tree", () => {
+    expect(filtering.addParents(balancedTree(7), [])).toEqual([]);
+    expect(filtering.addParents([], [])).toEqual([]);
+    const nodes = balancedTree(1);
+    expect(filtering.addParents(nodes, nodes)).toEqual(nodes);
+  });
+
+  it("includes a long ancestor chain without recursive traversal", () => {
+    const nodes = Array.from({ length: 20000 }, (_, node_id) => ({
+      node_id,
+      parent_id: Math.min(node_id + 1, 19999),
+    }));
+
+    expect(filtering.addParents(nodes, [nodes[0]])).toEqual(nodes);
+  });
+});
+
+describe("getNodes", () => {
+  it.each(["x_dist", "x_time"])(
+    "returns a sparse viewport and its ancestors without visiting unrelated nodes (%s)",
+    (xType) => {
+      const nodes = balancedTree(10);
+      const yPositions = nodes.map((node) => node.y);
+      // This unrelated tip is outside the viewport and every ancestor path.
+      // Reading it would reveal a full-tree scan without relying on timings.
+      Object.defineProperty(nodes, 900, {
+        get() {
+          throw new Error("Visited a node outside the viewport and its ancestors");
+        },
+      });
+      const minX = xType === "x_time" ? 2000 : 0;
+      const result = filtering.getNodes(
+        nodes, yPositions, 0, 2, minX, minX + 10, xType,
+      );
+
+      expect(result.map((node) => node.node_id)).toEqual([
+        0, 1, 2, 3, 7, 15, 31, 63, 127, 255, 511,
+      ]);
+    },
+  );
+
+  it("preserves whole-tree queries", () => {
+    const nodes = balancedTree(7);
+    const result = filtering.getNodes(
+      nodes, nodes.map((node) => node.y), 0, 126, 0, 7, "x_dist",
+    );
+
+    expect(result).toEqual(nodes);
+  });
+
+  it("hydrates mutations without changing the stored nodes", () => {
+    const nodes = balancedTree(7);
+    const mutation = { mutation_id: 0 };
+    const result = filtering.getNodes(
+      nodes, nodes.map((node) => node.y), 0, 0.5, 0, 7, "x_dist", true, [mutation],
+    );
+
+    expect(result.map((node) => node.node_id)).toEqual([0, 1, 3, 7, 15, 31, 63]);
+    result.forEach((node) => {
+      expect(node.mutations).toEqual([mutation]);
+      expect(node).not.toBe(nodes[node.node_id]);
+      expect(nodes[node.node_id].mutations).toEqual([0]);
+    });
+  });
+});

--- a/taxonium_data_handling/filtering.js
+++ b/taxonium_data_handling/filtering.js
@@ -105,9 +105,11 @@ function search(input, search_spec) {}
 
 const addParents = (data, filtered) => {
   const start_time = Date.now();
-  const selected_node_ids = filtered.map((node) => node.node_id);
-  // creat a set to keep track of selected_node_ids
-  const selected_node_ids_set = new Set(selected_node_ids);
+  const selected_node_ids_set = new Set();
+  for (const node of filtered) {
+    selected_node_ids_set.add(node.node_id);
+  }
+  const selected_node_ids = Array.from(selected_node_ids_set);
   const starting_size = filtered.length;
   for (let i = 0; i < selected_node_ids.length; i++) {
     const node_id = selected_node_ids[i];
@@ -122,9 +124,13 @@ const addParents = (data, filtered) => {
       //console.log("New length is", selected_node_ids.length);
     }
   }
-  const with_parents = data.filter((node) =>
-    selected_node_ids_set.has(node.node_id)
-  );
+  // Node IDs are array indices, so sorting the selected IDs preserves data order
+  // without scanning the whole tree. Keep the linear scan for dense selections,
+  // where sorting would do more work. Both paths reuse the existing IDs and set.
+  const with_parents =
+    selected_node_ids.length * Math.log2(selected_node_ids.length + 1) < data.length
+      ? selected_node_ids.sort((a, b) => a - b).map((id) => data[id])
+      : data.filter((node) => selected_node_ids_set.has(node.node_id));
   const final_size = with_parents.length;
   console.log("Adding parents took " + (Date.now() - start_time) + "ms.");
   console.log("Went from " + starting_size + " to " + final_size + " nodes.");


### PR DESCRIPTION
Zoomed-in viewport queries currently scan every node in the tree after collecting the visible tips and their ancestors. Retrieve small selections directly by node ID instead, sorting those IDs to preserve the existing result order. Keep the linear scan for dense selections using a `K * log2(K + 1) < N` estimate. This adds no persistent tree-sized index and preserves shared ancestors, duplicate handling, and node object identity.

Synthetic balanced-tree benchmarks against `ae4bceba`, using Node 22.13.1, two warm-up iterations and the median of nine alternating runs:

| Total nodes | Query | Returned nodes | Before | After |
| --- | --- | --- | --- | --- |
| 1,048,575 | Narrow viewport | 2,020 | 21.94 ms | 0.52 ms |
| 4,194,303 | Narrow viewport | 2,020 | 89.07 ms | 0.46 ms |
| 4,194,303 | 2% Y range | 12,638 | 105.24 ms | 7.29 ms |
| 4,194,303 | Whole tree | 24,057 | 351.91 ms | 245.67 ms |
| 16,383 | Dense selection | 8,049 | 2.57 ms | 2.68 ms |

These timings cover `getNodes`, not browser rendering or overall animation frame rate. Output IDs and ordering matched the original implementation for every benchmark case. Browser peak memory has not been measured; the change reuses the existing selection IDs and set, with temporary sorting storage proportional to the selection.

Validation: `npm test` passes all 25 tests and `npm run check-types` passes with zero errors. Eight new tests cover sparse queries without visiting unrelated nodes, numeric result ordering, shared ancestors and duplicate inputs, dense and whole-tree selections, empty/root-only trees, long ancestor chains, both X coordinate modes, and mutation hydration.
